### PR TITLE
Add char typed events for handling `Screen::charTyped`

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenKeyboardEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenKeyboardEvents.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.client.screen.v1;
 import java.util.Objects;
 
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 
 import net.fabricmc.fabric.api.event.Event;
@@ -104,6 +105,39 @@ public final class ScreenKeyboardEvents {
 		return ScreenExtensions.getExtensions(screen).fabric_getAfterKeyReleaseEvent();
 	}
 
+	/**
+	 * An event that checks if typing a character should be allowed.
+	 *
+	 * @return the event
+	 */
+	public static Event<AllowCharType> allowCharType(Screen screen) {
+		Objects.requireNonNull(screen, "Screen cannot be null");
+
+		return ScreenExtensions.getExtensions(screen).fabric_getAllowCharTypeEvent();
+	}
+
+	/**
+	 * An event that is called before typing a character is processed for a screen.
+	 *
+	 * @return the event
+	 */
+	public static Event<BeforeCharType> beforeCharType(Screen screen) {
+		Objects.requireNonNull(screen, "Screen cannot be null");
+
+		return ScreenExtensions.getExtensions(screen).fabric_getBeforeCharTypeEvent();
+	}
+
+	/**
+	 * An event that is called after typing a character is processed for a screen.
+	 *
+	 * @return the event
+	 */
+	public static Event<AfterCharType> afterCharType(Screen screen) {
+		Objects.requireNonNull(screen, "Screen cannot be null");
+
+		return ScreenExtensions.getExtensions(screen).fabric_getAfterCharTypeEvent();
+	}
+
 	private ScreenKeyboardEvents() {
 	}
 
@@ -179,5 +213,42 @@ public final class ScreenKeyboardEvents {
 		 * @see <a href="https://www.glfw.org/docs/3.3/group__mods.html">Modifier key flags</a>
 		 */
 		void afterKeyRelease(Screen screen, KeyEvent event);
+	}
+
+	@FunctionalInterface
+	public interface AllowCharType {
+		/**
+		 * Checks if typing a character should be allowed.
+		 *
+		 * @param event the char type event, containing the codepoint and modifiers
+		 * @return whether the character should be typed
+		 * @see CharacterEvent#codepointAsString()
+		 * @see <a href="https://www.glfw.org/docs/3.3/group__mods.html">Modifier key flags</a>
+		 */
+		boolean allowCharType(Screen screen, CharacterEvent event);
+	}
+
+	@FunctionalInterface
+	public interface BeforeCharType {
+		/**
+		 * Called before a character is typed.
+		 *
+		 * @param event the char type event, containing the codepoint and modifiers
+		 * @see CharacterEvent#codepointAsString()
+		 * @see <a href="https://www.glfw.org/docs/3.3/group__mods.html">Modifier key flags</a>
+		 */
+		void beforeCharType(Screen screen, CharacterEvent event);
+	}
+
+	@FunctionalInterface
+	public interface AfterCharType {
+		/**
+		 * Called after a character is typed.
+		 *
+		 * @param event the char type event, containing the codepoint and modifiers
+		 * @see CharacterEvent#codepointAsString()
+		 * @see <a href="https://www.glfw.org/docs/3.3/group__mods.html">Modifier key flags</a>
+		 */
+		void afterCharType(Screen screen, CharacterEvent event);
 	}
 }

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenKeyboardEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenKeyboardEvents.java
@@ -220,7 +220,7 @@ public final class ScreenKeyboardEvents {
 		/**
 		 * Checks if typing a character should be allowed.
 		 *
-		 * @param event the char type event, containing the codepoint and modifiers
+		 * @param event the char type event, containing the codepoint
 		 * @return whether the character should be typed
 		 * @see CharacterEvent#codepointAsString()
 		 * @see <a href="https://www.glfw.org/docs/3.3/group__mods.html">Modifier key flags</a>
@@ -233,7 +233,7 @@ public final class ScreenKeyboardEvents {
 		/**
 		 * Called before a character is typed.
 		 *
-		 * @param event the char type event, containing the codepoint and modifiers
+		 * @param event the char type event, containing the codepoint
 		 * @see CharacterEvent#codepointAsString()
 		 * @see <a href="https://www.glfw.org/docs/3.3/group__mods.html">Modifier key flags</a>
 		 */
@@ -245,7 +245,7 @@ public final class ScreenKeyboardEvents {
 		/**
 		 * Called after a character is typed.
 		 *
-		 * @param event the char type event, containing the codepoint and modifiers
+		 * @param event the char type event, containing the codepoint
 		 * @see CharacterEvent#codepointAsString()
 		 * @see <a href="https://www.glfw.org/docs/3.3/group__mods.html">Modifier key flags</a>
 		 */

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
@@ -77,9 +77,9 @@ public final class ScreenEventFactory {
 	// Keyboard events
 
 	public static Event<ScreenKeyboardEvents.AllowKeyPress> createAllowKeyPressEvent() {
-		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AllowKeyPress.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AllowKeyPress.class, callbacks -> (screen, event) -> {
 			for (ScreenKeyboardEvents.AllowKeyPress callback : callbacks) {
-				if (!callback.allowKeyPress(screen, context)) {
+				if (!callback.allowKeyPress(screen, event)) {
 					return false;
 				}
 			}
@@ -89,25 +89,25 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenKeyboardEvents.BeforeKeyPress> createBeforeKeyPressEvent() {
-		return EventFactory.createArrayBacked(ScreenKeyboardEvents.BeforeKeyPress.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenKeyboardEvents.BeforeKeyPress.class, callbacks -> (screen, event) -> {
 			for (ScreenKeyboardEvents.BeforeKeyPress callback : callbacks) {
-				callback.beforeKeyPress(screen, context);
+				callback.beforeKeyPress(screen, event);
 			}
 		});
 	}
 
 	public static Event<ScreenKeyboardEvents.AfterKeyPress> createAfterKeyPressEvent() {
-		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AfterKeyPress.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AfterKeyPress.class, callbacks -> (screen, event) -> {
 			for (ScreenKeyboardEvents.AfterKeyPress callback : callbacks) {
-				callback.afterKeyPress(screen, context);
+				callback.afterKeyPress(screen, event);
 			}
 		});
 	}
 
 	public static Event<ScreenKeyboardEvents.AllowKeyRelease> createAllowKeyReleaseEvent() {
-		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AllowKeyRelease.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AllowKeyRelease.class, callbacks -> (screen, event) -> {
 			for (ScreenKeyboardEvents.AllowKeyRelease callback : callbacks) {
-				if (!callback.allowKeyRelease(screen, context)) {
+				if (!callback.allowKeyRelease(screen, event)) {
 					return false;
 				}
 			}
@@ -117,17 +117,45 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenKeyboardEvents.BeforeKeyRelease> createBeforeKeyReleaseEvent() {
-		return EventFactory.createArrayBacked(ScreenKeyboardEvents.BeforeKeyRelease.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenKeyboardEvents.BeforeKeyRelease.class, callbacks -> (screen, event) -> {
 			for (ScreenKeyboardEvents.BeforeKeyRelease callback : callbacks) {
-				callback.beforeKeyRelease(screen, context);
+				callback.beforeKeyRelease(screen, event);
 			}
 		});
 	}
 
 	public static Event<ScreenKeyboardEvents.AfterKeyRelease> createAfterKeyReleaseEvent() {
-		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AfterKeyRelease.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AfterKeyRelease.class, callbacks -> (screen, event) -> {
 			for (ScreenKeyboardEvents.AfterKeyRelease callback : callbacks) {
-				callback.afterKeyRelease(screen, context);
+				callback.afterKeyRelease(screen, event);
+			}
+		});
+	}
+
+	public static Event<ScreenKeyboardEvents.AllowCharType> createAllowCharTypeEvent() {
+		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AllowCharType.class, callbacks -> (screen, event) -> {
+			for (ScreenKeyboardEvents.AllowCharType callback : callbacks) {
+				if (!callback.allowCharType(screen, event)) {
+					return false;
+				}
+			}
+
+			return true;
+		});
+	}
+
+	public static Event<ScreenKeyboardEvents.BeforeCharType> createBeforeCharTypeEvent() {
+		return EventFactory.createArrayBacked(ScreenKeyboardEvents.BeforeCharType.class, callbacks -> (screen, event) -> {
+			for (ScreenKeyboardEvents.BeforeCharType callback : callbacks) {
+				callback.beforeCharType(screen, event);
+			}
+		});
+	}
+
+	public static Event<ScreenKeyboardEvents.AfterCharType> createAfterCharTypeEvent() {
+		return EventFactory.createArrayBacked(ScreenKeyboardEvents.AfterCharType.class, callbacks -> (screen, event) -> {
+			for (ScreenKeyboardEvents.AfterCharType callback : callbacks) {
+				callback.afterCharType(screen, event);
 			}
 		});
 	}
@@ -135,9 +163,9 @@ public final class ScreenEventFactory {
 	// Mouse Events
 
 	public static Event<ScreenMouseEvents.AllowMouseClick> createAllowMouseClickEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.AllowMouseClick.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AllowMouseClick.class, callbacks -> (screen, event) -> {
 			for (ScreenMouseEvents.AllowMouseClick callback : callbacks) {
-				if (!callback.allowMouseClick(screen, context)) {
+				if (!callback.allowMouseClick(screen, event)) {
 					return false;
 				}
 			}
@@ -147,19 +175,19 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenMouseEvents.BeforeMouseClick> createBeforeMouseClickEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.BeforeMouseClick.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.BeforeMouseClick.class, callbacks -> (screen, event) -> {
 			for (ScreenMouseEvents.BeforeMouseClick callback : callbacks) {
-				callback.beforeMouseClick(screen, context);
+				callback.beforeMouseClick(screen, event);
 			}
 		});
 	}
 
 	public static Event<ScreenMouseEvents.AfterMouseClick> createAfterMouseClickEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseClick.class, callbacks -> (screen, context, consumed) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseClick.class, callbacks -> (screen, event, consumed) -> {
 			boolean consume = false;
 
 			for (ScreenMouseEvents.AfterMouseClick callback : callbacks) {
-				consume |= callback.afterMouseClick(screen, context, consume | consumed);
+				consume |= callback.afterMouseClick(screen, event, consume | consumed);
 			}
 
 			return consume;
@@ -167,9 +195,9 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenMouseEvents.AllowMouseRelease> createAllowMouseReleaseEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.AllowMouseRelease.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AllowMouseRelease.class, callbacks -> (screen, event) -> {
 			for (ScreenMouseEvents.AllowMouseRelease callback : callbacks) {
-				if (!callback.allowMouseRelease(screen, context)) {
+				if (!callback.allowMouseRelease(screen, event)) {
 					return false;
 				}
 			}
@@ -179,19 +207,19 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenMouseEvents.BeforeMouseRelease> createBeforeMouseReleaseEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.BeforeMouseRelease.class, callbacks -> (screen, context) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.BeforeMouseRelease.class, callbacks -> (screen, event) -> {
 			for (ScreenMouseEvents.BeforeMouseRelease callback : callbacks) {
-				callback.beforeMouseRelease(screen, context);
+				callback.beforeMouseRelease(screen, event);
 			}
 		});
 	}
 
 	public static Event<ScreenMouseEvents.AfterMouseRelease> createAfterMouseReleaseEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseRelease.class, callbacks -> (screen, context, consumed) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseRelease.class, callbacks -> (screen, event, consumed) -> {
 			boolean consume = false;
 
 			for (ScreenMouseEvents.AfterMouseRelease callback : callbacks) {
-				consume |= callback.afterMouseRelease(screen, context, consume | consumed);
+				consume |= callback.afterMouseRelease(screen, event, consume | consumed);
 			}
 
 			return consume;
@@ -199,9 +227,9 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenMouseEvents.AllowMouseDrag> createAllowMouseDragEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.AllowMouseDrag.class, callbacks -> (screen, context, horizontalAmount, verticalAmount) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AllowMouseDrag.class, callbacks -> (screen, event, horizontalAmount, verticalAmount) -> {
 			for (ScreenMouseEvents.AllowMouseDrag callback : callbacks) {
-				if (!callback.allowMouseDrag(screen, context, horizontalAmount, verticalAmount)) {
+				if (!callback.allowMouseDrag(screen, event, horizontalAmount, verticalAmount)) {
 					return false;
 				}
 			}
@@ -211,19 +239,19 @@ public final class ScreenEventFactory {
 	}
 
 	public static Event<ScreenMouseEvents.BeforeMouseDrag> createBeforeMouseDragEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.BeforeMouseDrag.class, callbacks -> (screen, context, horizontalAmount, verticalAmount) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.BeforeMouseDrag.class, callbacks -> (screen, event, horizontalAmount, verticalAmount) -> {
 			for (ScreenMouseEvents.BeforeMouseDrag callback : callbacks) {
-				callback.beforeMouseDrag(screen, context, horizontalAmount, verticalAmount);
+				callback.beforeMouseDrag(screen, event, horizontalAmount, verticalAmount);
 			}
 		});
 	}
 
 	public static Event<ScreenMouseEvents.AfterMouseDrag> createAfterMouseDragEvent() {
-		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseDrag.class, callbacks -> (screen, context, horizontalAmount, verticalAmount, consumed) -> {
+		return EventFactory.createArrayBacked(ScreenMouseEvents.AfterMouseDrag.class, callbacks -> (screen, event, horizontalAmount, verticalAmount, consumed) -> {
 			boolean consume = false;
 
 			for (ScreenMouseEvents.AfterMouseDrag callback : callbacks) {
-				consume |= callback.afterMouseDrag(screen, context, horizontalAmount, verticalAmount, consume | consumed);
+				consume |= callback.afterMouseDrag(screen, event, horizontalAmount, verticalAmount, consume | consumed);
 			}
 
 			return consume;

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
@@ -59,6 +59,12 @@ public interface ScreenExtensions {
 
 	Event<ScreenKeyboardEvents.AfterKeyRelease> fabric_getAfterKeyReleaseEvent();
 
+	Event<ScreenKeyboardEvents.AllowCharType> fabric_getAllowCharTypeEvent();
+
+	Event<ScreenKeyboardEvents.BeforeCharType> fabric_getBeforeCharTypeEvent();
+
+	Event<ScreenKeyboardEvents.AfterCharType> fabric_getAfterCharTypeEvent();
+
 	// Mouse
 
 	Event<ScreenMouseEvents.AllowMouseClick> fabric_getAllowMouseClickEvent();

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/KeyboardHandlerMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/KeyboardHandlerMixin.java
@@ -23,6 +23,7 @@ import org.spongepowered.asm.mixin.injection.At;
 
 import net.minecraft.client.KeyboardHandler;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
@@ -30,46 +31,69 @@ import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
 @Mixin(KeyboardHandler.class)
 abstract class KeyboardHandlerMixin {
 	@WrapOperation(method = "keyPress", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;keyPressed(Lnet/minecraft/client/input/KeyEvent;)Z"))
-	private boolean invokeKeyPressedEvents(Screen screen, KeyEvent ctx, Operation<Boolean> operation) {
+	private boolean invokeKeyPressedEvents(Screen screen, KeyEvent event, Operation<Boolean> operation) {
 		// The screen passed to events is the same as the screen the handler method is called on,
 		// regardless of whether the screen changes within the handler or event invocations.
 
 		if (screen != null) {
-			if (!ScreenKeyboardEvents.allowKeyPress(screen).invoker().allowKeyPress(screen, ctx)) {
+			if (!ScreenKeyboardEvents.allowKeyPress(screen).invoker().allowKeyPress(screen, event)) {
 				// Set this press action as handled
 				return true;
 			}
 
-			ScreenKeyboardEvents.beforeKeyPress(screen).invoker().beforeKeyPress(screen, ctx);
+			ScreenKeyboardEvents.beforeKeyPress(screen).invoker().beforeKeyPress(screen, event);
 		}
 
-		boolean result = operation.call(screen, ctx);
+		boolean result = operation.call(screen, event);
 
 		if (screen != null) {
-			ScreenKeyboardEvents.afterKeyPress(screen).invoker().afterKeyPress(screen, ctx);
+			ScreenKeyboardEvents.afterKeyPress(screen).invoker().afterKeyPress(screen, event);
 		}
 
 		return result;
 	}
 
 	@WrapOperation(method = "keyPress", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;keyReleased(Lnet/minecraft/client/input/KeyEvent;)Z"))
-	private boolean invokeKeyReleasedEvents(Screen screen, KeyEvent ctx, Operation<Boolean> operation) {
+	private boolean invokeKeyReleasedEvents(Screen screen, KeyEvent event, Operation<Boolean> operation) {
 		// The screen passed to events is the same as the screen the handler method is called on,
 		// regardless of whether the screen changes within the handler or event invocations.
 
 		if (screen != null) {
-			if (!ScreenKeyboardEvents.allowKeyRelease(screen).invoker().allowKeyRelease(screen, ctx)) {
+			if (!ScreenKeyboardEvents.allowKeyRelease(screen).invoker().allowKeyRelease(screen, event)) {
 				// Set this release action as handled
 				return true;
 			}
 
-			ScreenKeyboardEvents.beforeKeyRelease(screen).invoker().beforeKeyRelease(screen, ctx);
+			ScreenKeyboardEvents.beforeKeyRelease(screen).invoker().beforeKeyRelease(screen, event);
 		}
 
-		boolean result = operation.call(screen, ctx);
+		boolean result = operation.call(screen, event);
 
 		if (screen != null) {
-			ScreenKeyboardEvents.afterKeyRelease(screen).invoker().afterKeyRelease(screen, ctx);
+			ScreenKeyboardEvents.afterKeyRelease(screen).invoker().afterKeyRelease(screen, event);
+		}
+
+		return result;
+	}
+
+	@WrapOperation(method = "charTyped", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;charTyped(Lnet/minecraft/client/input/CharacterEvent;)Z"))
+	private boolean invokeCharTypedEvents(Screen screen, CharacterEvent event, Operation<Boolean> operation) {
+		// The screen passed to events is the same as the screen the handler method is called on,
+		// regardless of whether the screen changes within the handler or event invocations.
+
+		if (screen != null) {
+			if (!ScreenKeyboardEvents.allowCharType(screen).invoker().allowCharType(screen, event)) {
+				// Set this type action as handled
+				return true;
+			}
+
+			ScreenKeyboardEvents.beforeCharType(screen).invoker().beforeCharType(screen, event);
+		}
+
+		boolean result = operation.call(screen, event);
+
+		if (screen != null) {
+			ScreenKeyboardEvents.afterCharType(screen).invoker().afterCharType(screen, event);
 		}
 
 		return result;

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -82,6 +82,12 @@ abstract class ScreenMixin implements ScreenExtensions {
 	private Event<ScreenKeyboardEvents.BeforeKeyRelease> beforeKeyReleaseEvent;
 	@Unique
 	private Event<ScreenKeyboardEvents.AfterKeyRelease> afterKeyReleaseEvent;
+	@Unique
+	private Event<ScreenKeyboardEvents.AllowCharType> allowCharTypeEvent;
+	@Unique
+	private Event<ScreenKeyboardEvents.BeforeCharType> beforeCharTypeEvent;
+	@Unique
+	private Event<ScreenKeyboardEvents.AfterCharType> afterCharTypeEvent;
 
 	// Mouse
 	@Unique
@@ -152,6 +158,9 @@ abstract class ScreenMixin implements ScreenExtensions {
 		this.allowKeyReleaseEvent = ScreenEventFactory.createAllowKeyReleaseEvent();
 		this.beforeKeyReleaseEvent = ScreenEventFactory.createBeforeKeyReleaseEvent();
 		this.afterKeyReleaseEvent = ScreenEventFactory.createAfterKeyReleaseEvent();
+		this.allowCharTypeEvent = ScreenEventFactory.createAllowCharTypeEvent();
+		this.beforeCharTypeEvent = ScreenEventFactory.createBeforeCharTypeEvent();
+		this.afterCharTypeEvent = ScreenEventFactory.createAfterCharTypeEvent();
 
 		// Mouse
 		this.allowMouseClickEvent = ScreenEventFactory.createAllowMouseClickEvent();
@@ -254,6 +263,21 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Override
 	public Event<ScreenKeyboardEvents.AfterKeyRelease> fabric_getAfterKeyReleaseEvent() {
 		return ensureEventsAreInitialized(this.afterKeyReleaseEvent);
+	}
+
+	@Override
+	public Event<ScreenKeyboardEvents.AllowCharType> fabric_getAllowCharTypeEvent() {
+		return ensureEventsAreInitialized(this.allowCharTypeEvent);
+	}
+
+	@Override
+	public Event<ScreenKeyboardEvents.BeforeCharType> fabric_getBeforeCharTypeEvent() {
+		return ensureEventsAreInitialized(this.beforeCharTypeEvent);
+	}
+
+	@Override
+	public Event<ScreenKeyboardEvents.AfterCharType> fabric_getAfterCharTypeEvent() {
+		return ensureEventsAreInitialized(this.afterCharTypeEvent);
 	}
 
 	// Mouse

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
@@ -78,13 +78,18 @@ public final class ScreenTests implements ClientModInitializer {
 					.findAny()
 					.orElseThrow(() -> new AssertionError("Failed to find the \"Stop Sound\" button in the screen's elements"));
 
-			ScreenKeyboardEvents.allowKeyPress(screen).register((_screen, context) -> {
-				LOGGER.info("After Pressed, Context: {}", context);
+			ScreenKeyboardEvents.allowKeyPress(screen).register((_screen, event) -> {
+				LOGGER.info("Allow Key Press, Event: {}", event);
 				return true; // Let actions continue
 			});
 
-			ScreenKeyboardEvents.afterKeyPress(screen).register((_screen, context) -> {
-				LOGGER.warn("Pressed, Context: {}", context);
+			ScreenKeyboardEvents.afterKeyPress(screen).register((_screen, event) -> {
+				LOGGER.warn("After Key Press, Event: {}", event);
+			});
+
+			ScreenKeyboardEvents.allowCharType(screen).register((_screen, event) -> {
+				LOGGER.warn("Allow Char Type, Event: {}, Character: {}", event, event.codepointAsString());
+				return true;
 			});
 		} else if (screen instanceof CreativeModeInventoryScreen) {
 			Screens.getWidgets(screen).add(new TestButton());


### PR DESCRIPTION
Fabric was missing events for that, NeoForge already has them.

Came across this when implementing my own keybind that is processed when a screen is open.
For the creative inventory screen when the search tab is open there was no way to prevent my pressed key (when set to a letter) from adding a char to the search field, so these new events allow for preventing that.