### PR TITLE
Fix vanilla bug preventing adding optional elements to tag in datagen

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/TagAppenderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/TagAppenderMixin.java
@@ -16,9 +16,12 @@
 
 package net.fabricmc.fabric.mixin.datagen;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
 
 import net.minecraft.data.tags.TagAppender;
 import net.minecraft.tags.TagBuilder;
@@ -70,6 +73,14 @@ interface TagAppenderMixin<E, T> extends FabricTagAppender<E, T> {
 		public TagAppender<E, T> forceAddTag(TagKey<T> tag) {
 			((FabricTagAppender) this.val$original).forceAddTag(tag);
 			return (TagAppender<E, T>) this;
+		}
+
+		@WrapOperation(
+				method = "addOptional",
+				at = @At(value = "INVOKE", target = "Lnet/minecraft/data/tags/TagAppender;add(Ljava/lang/Object;)Lnet/minecraft/data/tags/TagAppender;")
+		)
+		private TagAppender<E, T> fixAddOptional(TagAppender instance, E e, Operation<TagAppender<E, T>> original) {
+			return instance.addOptional(e);
 		}
 	}
 }


### PR DESCRIPTION
In vanilla, there is a datagen bug where `TagAppender$2#addOptional` calls `TagAppender#add` instead of `TagAppender#addOptional`. This means that any `TagAppender` produced by `TagAppender#map`, such as `FabricIntrinsicHolderTagsProvider#valueLookupBuilder`, cannot add optional elements as they are handled like required elements. This PR fixes that bug.

This is my first PR so please let me know if the inject should be moved to a different mixin or if it needs tests or other style issues.
