### PR TITLE
Add transitive access wideners for new `Enchantment` functional interfaces

### DIFF
--- a/fabric-transitive-access-wideners-v1/build.gradle
+++ b/fabric-transitive-access-wideners-v1/build.gradle
@@ -169,6 +169,8 @@ def generateEnchantmentMethods(List<String> lines, FileSystem fs) {
 	}
 	lines.add('transitive-accessible class net/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentVisitor')
 	lines.add('transitive-accessible class net/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentInSlotVisitor')
+	lines.add('transitive-accessible class net/minecraft/world/item/enchantment/Enchantment$GenericAction')
+	lines.add('transitive-accessible class net/minecraft/world/item/enchantment/Enchantment$FloatAction')
 }
 
 ClassNode loadClass(Path path) {

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.classtweaker
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.classtweaker
@@ -320,6 +320,8 @@ transitive-accessible method net/minecraft/world/item/enchantment/Enchantment ap
 transitive-accessible method net/minecraft/world/item/enchantment/Enchantment applyEffects (Ljava/util/List;Lnet/minecraft/world/level/storage/loot/LootContext;Lorg/apache/commons/lang3/mutable/MutableFloat;Lnet/minecraft/world/item/enchantment/Enchantment$FloatAction;)V
 transitive-accessible class net/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentVisitor
 transitive-accessible class net/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentInSlotVisitor
+transitive-accessible class net/minecraft/world/item/enchantment/Enchantment$GenericAction
+transitive-accessible class net/minecraft/world/item/enchantment/Enchantment$FloatAction
 
 # private fields of RenderPipelines
 transitive-accessible field net/minecraft/client/renderer/RenderPipelines MATRICES_PROJECTION_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.classtweaker
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.classtweaker
@@ -320,8 +320,6 @@ transitive-accessible method net/minecraft/world/item/enchantment/Enchantment ap
 transitive-accessible method net/minecraft/world/item/enchantment/Enchantment applyEffects (Ljava/util/List;Lnet/minecraft/world/level/storage/loot/LootContext;Lorg/apache/commons/lang3/mutable/MutableFloat;Lnet/minecraft/world/item/enchantment/Enchantment$FloatAction;)V
 transitive-accessible class net/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentVisitor
 transitive-accessible class net/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentInSlotVisitor
-transitive-accessible class net/minecraft/world/item/enchantment/Enchantment$GenericAction
-transitive-accessible class net/minecraft/world/item/enchantment/Enchantment$FloatAction
 
 # private fields of RenderPipelines
 transitive-accessible field net/minecraft/client/renderer/RenderPipelines MATRICES_PROJECTION_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;


### PR DESCRIPTION
At some point during the snapshot cycle `Enchantment#applyEffects` was modified to use the private functional interfaces `GenericAction` and `FloatAction`, which made it impossible to use the access-widened `applyEffects` without adding your own access wideners. This PR makes those functional interfaces public so `applyEffects` can be used properly.