### PR TITLE
Fix bundle packet order

### DIFF
--- a/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/client/java/net/fabricmc/fabric/impl/networking/client/ClientPlayNetworkAddon.java
@@ -69,9 +69,13 @@ public final class ClientPlayNetworkAddon extends ClientCommonNetworkAddon<Clien
 
 	@Override
 	protected void receive(ClientPlayNetworking.PlayPayloadHandler<?> handler, CustomPayload payload) {
-		this.client.execute(() -> {
+		if (this.client.isOnThread()) {
 			((ClientPlayNetworking.PlayPayloadHandler) handler).receive(payload, context);
-		});
+		} else {
+			this.client.execute(() -> {
+				((ClientPlayNetworking.PlayPayloadHandler) handler).receive(payload, context);
+			});
+		}
 	}
 
 	// impl details

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
@@ -69,7 +69,6 @@ public abstract class AbstractChanneledNetworkAddon<H> extends AbstractNetworkAd
 		}
 	}
 
-	// always supposed to handle async!
 	public boolean handle(CustomPayload payload) {
 		final Identifier channelName = payload.getId().id();
 		this.logger.debug("Handling inbound packet from channel with name \"{}\"", channelName);

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerPlayNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/server/ServerPlayNetworkAddon.java
@@ -68,9 +68,13 @@ public final class ServerPlayNetworkAddon extends AbstractChanneledNetworkAddon<
 
 	@Override
 	protected void receive(ServerPlayNetworking.PlayPayloadHandler<?> payloadHandler, CustomPayload payload) {
-		this.server.execute(() -> {
+		if (this.server.isOnThread()) {
 			((ServerPlayNetworking.PlayPayloadHandler) payloadHandler).receive(payload, ServerPlayNetworkAddon.this.context);
-		});
+		} else {
+			this.server.execute(() -> {
+				((ServerPlayNetworking.PlayPayloadHandler) payloadHandler).receive(payload, ServerPlayNetworkAddon.this.context);
+			});
+		}
 	}
 
 	// impl details


### PR DESCRIPTION
Backport of https://github.com/FabricMC/fabric-api/pull/4897 to 1.21.1

I decided not to use exceptions as packet logic like vanilla does to not introduce extra overhead. Instead, the packets are only scheduled if not on the current thread.