### PR TITLE
Client gametest: allow compute methods to return nullable

### DIFF
--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/context/ClientGameTestContext.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/context/ClientGameTestContext.java
@@ -215,5 +215,5 @@ public interface ClientGameTestContext {
 	 * @param <E> The type of the checked exception that the function throws
 	 * @throws E When the function throws an exception
 	 */
-	<T, E extends Throwable> T computeOnClient(FailableFunction<Minecraft, T, E> function) throws E;
+	<T extends @Nullable Object, E extends Throwable> T computeOnClient(FailableFunction<Minecraft, T, E> function) throws E;
 }

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/context/TestServerContext.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/api/client/gametest/v1/context/TestServerContext.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.client.gametest.v1.context;
 import org.apache.commons.lang3.function.FailableConsumer;
 import org.apache.commons.lang3.function.FailableFunction;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 import net.minecraft.server.MinecraftServer;
 
@@ -55,5 +56,5 @@ public interface TestServerContext {
 	 * @param <E> The type of the checked exception that the function throws
 	 * @throws E When the function throws an exception
 	 */
-	<T, E extends Throwable> T computeOnServer(FailableFunction<MinecraftServer, T, E> function) throws E;
+	<T extends @Nullable Object, E extends Throwable> T computeOnServer(FailableFunction<MinecraftServer, T, E> function) throws E;
 }


### PR DESCRIPTION
Same reason as https://github.com/FabricMC/fabric-api/pull/5172.