### PR TITLE
Implement dynamic block tinting support with BlockTintsFactory integration

### DIFF
--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
@@ -22,6 +22,10 @@ import java.util.function.Predicate;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
+
 import org.joml.Vector3f;
 import org.jspecify.annotations.Nullable;
 
@@ -201,6 +205,19 @@ public class AltModelBlockRendererImpl implements AltModelBlockRenderer, QuadTra
 		if (!tintSourcesInitialized) {
 			configureTintCache(state);
 			tintSourcesInitialized = true;
+
+			if (this.tintSources.isEmpty()) {
+				final BlockTintsFactory factory = BlockColorRegistry.factoryFor(state);
+				if (factory != null) {
+					factory.collect(state, level, pos, this.computedTintValues);
+				}
+
+				if (!this.computedTintValues.isEmpty()) {
+					for (int i = 0; i < this.computedTintValues.size(); i++) {
+						this.tintSources.add(null);
+					}
+				}
+			}
 		}
 
 		if (tintIndex >= tintSources.size()) {

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
@@ -200,6 +200,7 @@ public class AltModelBlockRendererImpl implements AltModelBlockRenderer, QuadTra
 			}
 		} else {
 			final BlockTintsFactory factory = BlockColorRegistry.getFactory(blockState);
+
 			if (factory != null) {
 				factory.collect(blockState, level, pos, computedTintValues);
 			}

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
@@ -22,10 +22,6 @@ import java.util.function.Predicate;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-
-import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
-
 import org.joml.Vector3f;
 import org.jspecify.annotations.Nullable;
 
@@ -49,6 +45,8 @@ import net.fabricmc.fabric.api.client.renderer.v1.mesh.QuadTransform;
 import net.fabricmc.fabric.api.client.renderer.v1.mesh.ShadeMode;
 import net.fabricmc.fabric.api.client.renderer.v1.render.AltModelBlockRenderer;
 import net.fabricmc.fabric.api.client.renderer.v1.render.ExtraLightCoordsUtil;
+import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
 import net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.AoCalculator;
 import net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.FlatLighter;
 import net.fabricmc.fabric.impl.client.indigo.renderer.mesh.MutableQuadViewImpl;

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/AltModelBlockRendererImpl.java
@@ -188,7 +188,9 @@ public class AltModelBlockRendererImpl implements AltModelBlockRenderer, QuadTra
 		}
 	}
 
-	private void configureTintCache(final BlockState blockState) {
+	private void configureTintCache(final BlockState blockState,
+			final BlockAndTintGetter level,
+			final BlockPos pos) {
 		List<BlockTintSource> tintSources = blockColors.getTintSources(blockState);
 		int tintSourceCount = tintSources.size();
 
@@ -198,26 +200,24 @@ public class AltModelBlockRendererImpl implements AltModelBlockRenderer, QuadTra
 			for (int i = 0; i < tintSourceCount; ++i) {
 				computedTintValues.add(-1);
 			}
+		} else {
+			final BlockTintsFactory factory = BlockColorRegistry.getFactory(blockState);
+			if (factory != null) {
+				factory.collect(blockState, level, pos, computedTintValues);
+			}
+
+			if (!this.computedTintValues.isEmpty()) {
+				for (int i = 0; i < this.computedTintValues.size(); i++) {
+					this.tintSources.add(null);
+				}
+			}
 		}
 	}
 
 	private int computeTintColor(final BlockAndTintGetter level, final BlockState state, final BlockPos pos, final int tintIndex) {
 		if (!tintSourcesInitialized) {
-			configureTintCache(state);
+			configureTintCache(state, level, pos);
 			tintSourcesInitialized = true;
-
-			if (this.tintSources.isEmpty()) {
-				final BlockTintsFactory factory = BlockColorRegistry.factoryFor(state);
-				if (factory != null) {
-					factory.collect(state, level, pos, this.computedTintValues);
-				}
-
-				if (!this.computedTintValues.isEmpty()) {
-					for (int i = 0; i < this.computedTintValues.size(); i++) {
-						this.tintSources.add(null);
-					}
-				}
-			}
 		}
 
 		if (tintIndex >= tintSources.size()) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockColorRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockColorRegistry.java
@@ -25,6 +25,10 @@ import net.minecraft.world.level.block.Block;
 
 import net.fabricmc.fabric.impl.client.rendering.BlockColorRegistryImpl;
 
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.jspecify.annotations.Nullable;
+
 /**
  * The registry for {@link BlockTintSource}s.
  */
@@ -43,5 +47,26 @@ public final class BlockColorRegistry {
 	 */
 	public static void register(List<BlockTintSource> layers, Block... blocks) {
 		BlockColorRegistryImpl.register(layers, blocks);
+	}
+
+	/**
+	 * Register a block tint factory for one or more blocks. Overriding existing registration is allowed.
+	 *
+	 * @param factory The factory which allows dynamic tinting.
+	 * @param blocks The blocks which should be colored using the given factory.
+	 */
+	public static void register(BlockTintsFactory factory, Block... blocks) {
+		BlockColorRegistryImpl.register(factory, blocks);
+	}
+
+	/**
+	 * Retrieves the current {@link BlockTintsFactory factory}, or {@code null} if no factory exists,
+	 * for the given {@link BlockState block state}.
+	 *
+	 * @param blockState The block state to look up.
+	 * @return The factory.
+	 */
+	public static @Nullable BlockTintsFactory factoryFor(BlockState blockState) {
+		return BlockColorRegistryImpl.factoryFor(blockState);
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockColorRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockColorRegistry.java
@@ -66,7 +66,7 @@ public final class BlockColorRegistry {
 	 * @param blockState The block state to look up.
 	 * @return The factory.
 	 */
-	public static @Nullable BlockTintsFactory factoryFor(BlockState blockState) {
-		return BlockColorRegistryImpl.factoryFor(blockState);
+	public static @Nullable BlockTintsFactory getFactory(BlockState blockState) {
+		return BlockColorRegistryImpl.getFactory(blockState);
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockColorRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockColorRegistry.java
@@ -18,16 +18,15 @@ package net.fabricmc.fabric.api.client.rendering.v1;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.color.block.BlockTintSource;
 import net.minecraft.world.level.block.Block;
-
-import net.fabricmc.fabric.impl.client.rendering.BlockColorRegistryImpl;
-
 import net.minecraft.world.level.block.state.BlockState;
 
-import org.jspecify.annotations.Nullable;
+import net.fabricmc.fabric.impl.client.rendering.BlockColorRegistryImpl;
 
 /**
  * The registry for {@link BlockTintSource}s.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
@@ -53,6 +53,8 @@ public interface BlockTintsFactory
 	 *     The given tint list is guaranteed to be empty.
 	 *     It is recommended to call the {@link IntList#size(int) size} method if you at the start of the method, ahead of time, how many
 	 *     tints your system will eventually register as this will pre-allocate enough memory to hold your ints.
+	 *     If you use this mechanic, remember to use {@link IntList#set(int, int) set} instead of {@link IntList#add(int) add}
+	 *     to put the tint into the list, because add will always append to the end, even if pre-sized.
 	 * </p>
 	 *
 	 * @param state The state for which the tints are retrieved.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
@@ -25,30 +25,34 @@ import net.minecraft.world.level.block.state.BlockState;
 
 /**
  * This factory takes over the collection of tint colors in a model renderer.
+ *
  * <p>
  *     If this factory provides any tints in the tintValues collections of its {@link #collect(BlockState, BlockAndTintGetter, BlockPos, IntList)}
  *     method then the default vanilla behaviour of iterating the registered {@link net.minecraft.client.color.block.BlockTintSource block tint sources}
  *     is skipped.
  * </p>
+ *
  * <p>
  *     This factory is only invoked if no {@link net.minecraft.client.color.block.BlockTintSource tint source} has been registered for the {@link BlockState block state}.
  * </p>
  */
 @FunctionalInterface
-public interface BlockTintsFactory
-{
+public interface BlockTintsFactory {
 	/**
 	 * Invoked to collect the dynamic tint values for the given block state.
+	 *
 	 * <p>
 	 *     The tint applied to a given {@link net.minecraft.client.resources.model.geometry.BakedQuad quad}
 	 *     is then determined based on the index stored in {@link BakedQuad.MaterialInfo#tintIndex()} by looking
 	 *     them up in the tint values list after this collect method is called.
 	 * </p>
+	 *
 	 * <p>
 	 *     The resulting tints might be cached for this state, level and position, while the
 	 *     given position and model are rendered, but may not be stored beyond that time window,
 	 *     especially not beyond any given frame being rendered.
 	 * </p>
+	 *
 	 * <p>
 	 *     The given tint list is guaranteed to be empty.
 	 *     It is recommended to call the {@link IntList#size(int) size} method if you at the start of the method, ahead of time, how many
@@ -56,6 +60,7 @@ public interface BlockTintsFactory
 	 *     If you use this mechanic, remember to use {@link IntList#set(int, int) set} instead of {@link IntList#add(int) add}
 	 *     to put the tint into the list, because add will always append to the end, even if pre-sized.
 	 * </p>
+	 *
 	 * <p>
 	 *     This method will be invoked from multiple threads simultaneously, primarily from the chunk meshing threads,
 	 *     as such it is of the up most importance that you consider that while implementing this method.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
@@ -56,6 +56,12 @@ public interface BlockTintsFactory
 	 *     If you use this mechanic, remember to use {@link IntList#set(int, int) set} instead of {@link IntList#add(int) add}
 	 *     to put the tint into the list, because add will always append to the end, even if pre-sized.
 	 * </p>
+	 * <p>
+	 *     This method will be invoked from multiple threads simultaneously, primarily from the chunk meshing threads,
+	 *     as such it is of the up most importance that you consider that while implementing this method.
+	 *     In particular use the block entity render data system to access custom data, instead of directly
+	 *     accessing the underlying block entity in the given position.
+	 * </p>
 	 *
 	 * @param state The state for which the tints are retrieved.
 	 * @param level The level in which they are retrieved.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
@@ -33,6 +33,11 @@ public interface BlockTintsFactory
 	 *     given position and model are rendered, but may not be stored beyond that time window,
 	 *     especially not beyond any given frame being rendered.
 	 * </p>
+	 * <p>
+	 *     The given tint list is guaranteed to be empty.
+	 *     It is recommended to call the {@link IntList#size(int) size} method if you at the start of the method, ahead of time, how many
+	 *     tints your system will eventually register as this will pre-allocate enough memory to hold your ints.
+	 * </p>
 	 *
 	 * @param state The state for which the tints are retrieved.
 	 * @param level The level in which they are retrieved.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.client.rendering.v1;
 
 import it.unimi.dsi.fastutil.ints.IntList;

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/BlockTintsFactory.java
@@ -1,0 +1,43 @@
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * This factory takes over the collection of tint colors in a model renderer.
+ * <p>
+ *     If this factory provides any tints in the tintValues collections of its {@link #collect(BlockState, BlockAndTintGetter, BlockPos, IntList)}
+ *     method then the default vanilla behaviour of iterating the registered {@link net.minecraft.client.color.block.BlockTintSource block tint sources}
+ *     is skipped.
+ * </p>
+ * <p>
+ *     This factory is only invoked if no {@link net.minecraft.client.color.block.BlockTintSource tint source} has been registered for the {@link BlockState block state}.
+ * </p>
+ */
+@FunctionalInterface
+public interface BlockTintsFactory
+{
+	/**
+	 * Invoked to collect the dynamic tint values for the given block state.
+	 * <p>
+	 *     The tint applied to a given {@link net.minecraft.client.resources.model.geometry.BakedQuad quad}
+	 *     is then determined based on the index stored in {@link BakedQuad.MaterialInfo#tintIndex()} by looking
+	 *     them up in the tint values list after this collect method is called.
+	 * </p>
+	 * <p>
+	 *     The resulting tints might be cached for this state, level and position, while the
+	 *     given position and model are rendered, but may not be stored beyond that time window,
+	 *     especially not beyond any given frame being rendered.
+	 * </p>
+	 *
+	 * @param state The state for which the tints are retrieved.
+	 * @param level The level in which they are retrieved.
+	 * @param pos The position inside the level for which they are retrieved.
+	 * @param tintValues The target collection in which to store the tint values for the given index.
+	 */
+	void collect(BlockState state, BlockAndTintGetter level, BlockPos pos, IntList tintValues);
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BlockColorRegistryImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BlockColorRegistryImpl.java
@@ -49,8 +49,7 @@ public final class BlockColorRegistryImpl {
 	}
 
 	public static void register(List<BlockTintSource> layers, Block... blocks) {
-		for (final Block block : blocks)
-		{
+		for (final Block block : blocks) {
 			if (factories.containsKey(block)) {
 				throw new IllegalStateException("A dynamic block color factory for the block %s has already been registered and as such no static usage is allowed!".formatted(
 						block
@@ -67,15 +66,13 @@ public final class BlockColorRegistryImpl {
 		}
 	}
 
-	public static void register(final BlockTintsFactory factory, final Block[] blocks)
-	{
-		for (final Block block : blocks)
-		{
+	public static void register(final BlockTintsFactory factory, final Block[] blocks) {
+		for (final Block block : blocks) {
 			if (map != null && map.containsKey(block)) {
-				throw new IllegalStateException(
-						"A static block color provider for the block: %s has already been registered and as such no dynamic usage is allowed!".formatted(
-								block));
+				throw new IllegalStateException("A static block color provider for the block: %s has already been registered and as such no dynamic usage is allowed!".formatted(
+						block));
 			}
+
 			if (blockColors != null && !blockColors.getTintSources(block.defaultBlockState()).isEmpty()) {
 				throw new IllegalStateException(
 						"A static block color provider for the block: %s has already been registered and as such no dynamic usage is allowed!".formatted(
@@ -86,8 +83,7 @@ public final class BlockColorRegistryImpl {
 		}
 	}
 
-	public static @Nullable BlockTintsFactory getFactory(final BlockState blockState)
-	{
+	public static @Nullable BlockTintsFactory getFactory(final BlockState blockState) {
 		return factories.get(blockState.getBlock());
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BlockColorRegistryImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BlockColorRegistryImpl.java
@@ -20,15 +20,14 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
-
-import net.minecraft.world.level.block.state.BlockState;
-
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.color.block.BlockTintSource;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
 
 public final class BlockColorRegistryImpl {
 	@Nullable

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BlockColorRegistryImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BlockColorRegistryImpl.java
@@ -20,6 +20,11 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
+
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.client.color.block.BlockColors;
@@ -31,6 +36,8 @@ public final class BlockColorRegistryImpl {
 	private static BlockColors blockColors;
 	@Nullable
 	private static Map<Block, List<BlockTintSource>> map = new IdentityHashMap<>();
+
+	private static Map<Block, BlockTintsFactory> factories = new IdentityHashMap<>();
 
 	public static void initialize(BlockColors blockColors) {
 		if (BlockColorRegistryImpl.blockColors != null) {
@@ -51,5 +58,18 @@ public final class BlockColorRegistryImpl {
 				map.put(block, layers);
 			}
 		}
+	}
+
+	public static void register(final BlockTintsFactory factory, final Block[] blocks)
+	{
+		for (final Block block : blocks)
+		{
+			factories.put(block, factory);
+		}
+	}
+
+	public static @Nullable BlockTintsFactory factoryFor(final BlockState blockState)
+	{
+		return factories.get(blockState.getBlock());
 	}
 }

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BlockColorRegistryImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/BlockColorRegistryImpl.java
@@ -24,7 +24,6 @@ import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
 
 import net.minecraft.world.level.block.state.BlockState;
 
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.client.color.block.BlockColors;
@@ -51,6 +50,15 @@ public final class BlockColorRegistryImpl {
 	}
 
 	public static void register(List<BlockTintSource> layers, Block... blocks) {
+		for (final Block block : blocks)
+		{
+			if (factories.containsKey(block)) {
+				throw new IllegalStateException("A dynamic block color factory for the block %s has already been registered and as such no static usage is allowed!".formatted(
+						block
+				));
+			}
+		}
+
 		if (blockColors != null) {
 			blockColors.register(layers, blocks);
 		} else {
@@ -64,11 +72,22 @@ public final class BlockColorRegistryImpl {
 	{
 		for (final Block block : blocks)
 		{
+			if (map != null && map.containsKey(block)) {
+				throw new IllegalStateException(
+						"A static block color provider for the block: %s has already been registered and as such no dynamic usage is allowed!".formatted(
+								block));
+			}
+			if (blockColors != null && !blockColors.getTintSources(block.defaultBlockState()).isEmpty()) {
+				throw new IllegalStateException(
+						"A static block color provider for the block: %s has already been registered and as such no dynamic usage is allowed!".formatted(
+								block));
+			}
+
 			factories.put(block, factory);
 		}
 	}
 
-	public static @Nullable BlockTintsFactory factoryFor(final BlockState blockState)
+	public static @Nullable BlockTintsFactory getFactory(final BlockState blockState)
 	{
 		return factories.get(blockState.getBlock());
 	}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelBlockRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelBlockRendererMixin.java
@@ -51,7 +51,7 @@ public abstract class ModelBlockRendererMixin
 			final int tintIndex,
 			final CallbackInfoReturnable<Integer> cir) {
 		if (this.tintSources.isEmpty()) {
-			final BlockTintsFactory factory = BlockColorRegistry.factoryFor(state);
+			final BlockTintsFactory factory = BlockColorRegistry.getFactory(state);
 			if (factory != null) {
 				factory.collect(state, level, pos, this.computedTintValues);
 			}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelBlockRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelBlockRendererMixin.java
@@ -38,12 +38,10 @@ import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
 
 @Mixin(ModelBlockRenderer.class)
-public abstract class ModelBlockRendererMixin
-{
-
+public abstract class ModelBlockRendererMixin {
 	@Shadow
 	@Final
-	private IntList                         computedTintValues;
+	private IntList computedTintValues;
 	@Shadow
 	@Final
 	private List<@Nullable BlockTintSource> tintSources;
@@ -66,6 +64,7 @@ public abstract class ModelBlockRendererMixin
 			final CallbackInfoReturnable<Integer> cir) {
 		if (this.tintSources.isEmpty()) {
 			final BlockTintsFactory factory = BlockColorRegistry.getFactory(state);
+
 			if (factory != null) {
 				factory.collect(state, level, pos, this.computedTintValues);
 			}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelBlockRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelBlockRendererMixin.java
@@ -1,17 +1,24 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.client.rendering;
 
+import java.util.List;
+
 import it.unimi.dsi.fastutil.ints.IntList;
-
-import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
-
-import net.minecraft.client.color.block.BlockTintSource;
-import net.minecraft.client.renderer.block.BlockAndTintGetter;
-import net.minecraft.client.renderer.block.ModelBlockRenderer;
-
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.state.BlockState;
-
 import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
@@ -21,7 +28,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
+import net.minecraft.client.color.block.BlockTintSource;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.ModelBlockRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
 
 @Mixin(ModelBlockRenderer.class)
 public abstract class ModelBlockRendererMixin

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelBlockRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ModelBlockRendererMixin.java
@@ -1,0 +1,66 @@
+package net.fabricmc.fabric.mixin.client.rendering;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
+
+import net.minecraft.client.color.block.BlockTintSource;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.ModelBlockRenderer;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.jspecify.annotations.Nullable;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(ModelBlockRenderer.class)
+public abstract class ModelBlockRendererMixin
+{
+
+	@Shadow
+	@Final
+	private IntList                         computedTintValues;
+	@Shadow
+	@Final
+	private List<@Nullable BlockTintSource> tintSources;
+
+	@Inject(
+			method = "computeTintColor(Lnet/minecraft/client/renderer/block/BlockAndTintGetter;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;I)I",
+			at = @At(
+					value = "FIELD",
+					target = "Lnet/minecraft/client/renderer/block/ModelBlockRenderer;tintSourcesInitialized:Z",
+					opcode = Opcodes.PUTFIELD,
+					shift = At.Shift.AFTER
+			)
+
+	)
+	private void injectFactoryTintCacheLoading(
+			final BlockAndTintGetter level,
+			final BlockState state,
+			final BlockPos pos,
+			final int tintIndex,
+			final CallbackInfoReturnable<Integer> cir) {
+		if (this.tintSources.isEmpty()) {
+			final BlockTintsFactory factory = BlockColorRegistry.factoryFor(state);
+			if (factory != null) {
+				factory.collect(state, level, pos, this.computedTintValues);
+			}
+
+			if (!this.computedTintValues.isEmpty()) {
+				for (int i = 0; i < this.computedTintValues.size(); i++) {
+					this.tintSources.add(null);
+				}
+			}
+		}
+	}
+}

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -24,6 +24,7 @@
     "LevelRendererMixin",
     "LivingEntityRendererAccessor",
     "LivingEntityRendererMixin",
+    "ModelBlockRendererMixin",
     "ModelLayersAccessor",
     "ModelMixin",
     "ModelPartAccessor",

--- a/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/CustomColorResolverTestInit.java
+++ b/fabric-rendering-v1/src/testmod/java/net/fabricmc/fabric/test/rendering/CustomColorResolverTestInit.java
@@ -30,12 +30,18 @@ import net.fabricmc.api.ModInitializer;
 
 public class CustomColorResolverTestInit implements ModInitializer {
 	public static final ResourceKey<Block> KEY = ResourceKey.create(Registries.BLOCK, Identifier.fromNamespaceAndPath("fabric-rendering-v1-testmod", "custom_color_block"));
+	public static final ResourceKey<Block> KEY_DYNAMIC = ResourceKey.create(Registries.BLOCK, Identifier.fromNamespaceAndPath("fabric-rendering-v1-testmod", "custom_color_block_dynamic"));
 	public static final Block CUSTOM_COLOR_BLOCK = new Block(BlockBehaviour.Properties.of().setId(KEY));
+	public static final Block CUSTOM_COLOR_BLOCK_DYNAMIC = new Block(BlockBehaviour.Properties.of().setId(KEY_DYNAMIC));
+
 	public static final Item CUSTOM_COLOR_BLOCK_ITEM = new BlockItem(CUSTOM_COLOR_BLOCK, new Item.Properties().setId(ResourceKey.create(Registries.ITEM, KEY.identifier())));
+	public static final Item CUSTOM_COLOR_BLOCK_ITEM_DYNAMIC = new BlockItem(CUSTOM_COLOR_BLOCK_DYNAMIC, new Item.Properties().setId(ResourceKey.create(Registries.ITEM, KEY_DYNAMIC.identifier())));
 
 	@Override
 	public void onInitialize() {
 		Registry.register(BuiltInRegistries.BLOCK, KEY, CUSTOM_COLOR_BLOCK);
+		Registry.register(BuiltInRegistries.BLOCK, KEY_DYNAMIC, CUSTOM_COLOR_BLOCK_DYNAMIC);
 		Registry.register(BuiltInRegistries.ITEM, KEY.identifier(), CUSTOM_COLOR_BLOCK_ITEM);
+		Registry.register(BuiltInRegistries.ITEM, KEY_DYNAMIC.identifier(), CUSTOM_COLOR_BLOCK_ITEM_DYNAMIC);
 	}
 }

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/CustomColorResolverTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/CustomColorResolverTest.java
@@ -20,8 +20,6 @@ import java.util.List;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 
-import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
-
 import net.minecraft.client.color.block.BlockTintSource;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.core.BlockPos;
@@ -32,6 +30,7 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockColorRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorResolverRegistry;
 import net.fabricmc.fabric.test.rendering.CustomColorResolverTestInit;
 

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/CustomColorResolverTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/CustomColorResolverTest.java
@@ -18,9 +18,15 @@ package net.fabricmc.fabric.test.rendering.client;
 
 import java.util.List;
 
+import it.unimi.dsi.fastutil.ints.IntList;
+
+import net.fabricmc.fabric.api.client.rendering.v1.BlockTintsFactory;
+
 import net.minecraft.client.color.block.BlockTintSource;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.ARGB;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -50,9 +56,27 @@ public class CustomColorResolverTest implements ClientModInitializer {
 		}
 	};
 
+	private static final BlockTintsFactory TINTS_FACTORY = new BlockTintsFactory() {
+
+		private final RandomSource RANDOM = RandomSource.createThreadLocalInstance(42L);
+
+		@Override
+		public void collect(
+				final BlockState state,
+				final BlockAndTintGetter level,
+				final BlockPos pos,
+				final IntList tintValues)
+		{
+			tintValues.size(2);
+			tintValues.set(0, ARGB.color(255, RANDOM.nextInt()));
+			tintValues.set(1, ARGB.color(255, RANDOM.nextInt()));
+		}
+	};
+
 	@Override
 	public void onInitializeClient() {
 		ColorResolverRegistry.register(TEST_COLOR_RESOLVER);
 		BlockColorRegistry.register(List.of(TINT_SOURCE), CustomColorResolverTestInit.CUSTOM_COLOR_BLOCK);
+		BlockColorRegistry.register(TINTS_FACTORY, CustomColorResolverTestInit.CUSTOM_COLOR_BLOCK_DYNAMIC);
 	}
 }

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/CustomColorResolverTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/CustomColorResolverTest.java
@@ -58,7 +58,7 @@ public class CustomColorResolverTest implements ClientModInitializer {
 
 	private static final BlockTintsFactory TINTS_FACTORY = new BlockTintsFactory() {
 
-		private final RandomSource RANDOM = RandomSource.createThreadLocalInstance(42L);
+		private final ThreadLocal<RandomSource> RANDOM = ThreadLocal.withInitial(() -> RandomSource.createThreadLocalInstance(42L));
 
 		@Override
 		public void collect(
@@ -68,8 +68,8 @@ public class CustomColorResolverTest implements ClientModInitializer {
 				final IntList tintValues)
 		{
 			tintValues.size(2);
-			tintValues.set(0, ARGB.color(255, RANDOM.nextInt()));
-			tintValues.set(1, ARGB.color(255, RANDOM.nextInt()));
+			tintValues.set(0, ARGB.color(255, RANDOM.get().nextInt()));
+			tintValues.set(1, ARGB.color(255, RANDOM.get().nextInt()));
 		}
 	};
 

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/CustomColorResolverTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/CustomColorResolverTest.java
@@ -56,7 +56,6 @@ public class CustomColorResolverTest implements ClientModInitializer {
 	};
 
 	private static final BlockTintsFactory TINTS_FACTORY = new BlockTintsFactory() {
-
 		private final ThreadLocal<RandomSource> RANDOM = ThreadLocal.withInitial(() -> RandomSource.createThreadLocalInstance(42L));
 
 		@Override
@@ -64,8 +63,7 @@ public class CustomColorResolverTest implements ClientModInitializer {
 				final BlockState state,
 				final BlockAndTintGetter level,
 				final BlockPos pos,
-				final IntList tintValues)
-		{
+				final IntList tintValues) {
 			tintValues.size(2);
 			tintValues.set(0, ARGB.color(255, RANDOM.get().nextInt()));
 			tintValues.set(1, ARGB.color(255, RANDOM.get().nextInt()));

--- a/fabric-rendering-v1/src/testmodClient/resources/assets/fabric-rendering-v1-testmod/blockstates/custom_color_block_dynamic.json
+++ b/fabric-rendering-v1/src/testmodClient/resources/assets/fabric-rendering-v1-testmod/blockstates/custom_color_block_dynamic.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "fabric-rendering-v1-testmod:block/custom_color_block_dynamic"}
+  }
+}

--- a/fabric-rendering-v1/src/testmodClient/resources/assets/fabric-rendering-v1-testmod/models/block/custom_color_block_dynamic.json
+++ b/fabric-rendering-v1/src/testmodClient/resources/assets/fabric-rendering-v1-testmod/models/block/custom_color_block_dynamic.json
@@ -1,0 +1,20 @@
+{
+    "parent": "block/block",
+    "textures": {
+        "all": "fabric-rendering-v1-testmod:block/blank",
+        "particle": "#all"
+    },
+    "elements": [
+        {   "from": [ 0, 0, 0 ],
+            "to": [ 16, 16, 16 ],
+            "faces": {
+                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "down" },
+                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "tintindex": 0, "cullface": "up" },
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "tintindex": 1, "cullface": "north" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "south" },
+                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "west" },
+                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "east" }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### TLDR:
Implement a way for mods to provide dynamic tints if they can not know the amount and implementation of block tint sources at startup.

---

### Underlying changes:
- Provide an API which allows for the direct retrieval of the computed tint values and cache them for the duration of the render.
- Added a registration endpoint which allows modders to register the factories.

### Implementation:
- Mixin based implementation for the vanilla block model renderer
- Direct implementation for indigo