### PR TITLE
fix `VanillaTooltipOrderProvider` in remapped development environments

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipProviderOrder.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipProviderOrder.java
@@ -41,6 +41,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipDisplay;
 
+import net.fabricmc.loader.api.FabricLoader;
+
 public final class VanillaTooltipProviderOrder {
 	private static final List<DataComponentType<?>> VANILLA_ORDER = scrapeVanillaOrder();
 
@@ -56,8 +58,7 @@ public final class VanillaTooltipProviderOrder {
 		try {
 			ClassNode itemStackNode = MixinService.getService().getBytecodeProvider().getClassNode(Type.getInternalName(ItemStack.class));
 
-			String methodName = "addDetailsToTooltip";
-			String methodDesc = Type.getMethodDescriptor(
+			Type methodDescType = Type.getMethodType(
 					Type.VOID_TYPE,
 					Type.getType(Item.TooltipContext.class),
 					Type.getType(TooltipDisplay.class),
@@ -65,19 +66,34 @@ public final class VanillaTooltipProviderOrder {
 					Type.getType(TooltipFlag.class),
 					Type.getType(Consumer.class)
 			);
+			String methodDesc = methodDescType.getDescriptor();
 
-			String appendAttributeModifiersTooltipName = "addAttributeTooltips";
-			String appendAttributeModifiersTooltipDesc = Type.getMethodDescriptor(
+			String methodName = FabricLoader.getInstance().getMappingResolver().mapMethodName(
+					"official",
+					"net.minecraft.world.item.ItemStack",
+					"addDetailsToTooltip",
+					remapMethodDesc(methodDescType).getDescriptor()
+			);
+
+			Type appendAttributeModifiersTooltipDescType = Type.getMethodType(
 					Type.VOID_TYPE,
 					Type.getType(Consumer.class),
 					Type.getType(TooltipDisplay.class),
 					Type.getType(Player.class)
 			);
+			String appendAttributeModifiersTooltipDesc = appendAttributeModifiersTooltipDescType.getDescriptor();
+
+			String appendAttributeModifiersTooltipName = FabricLoader.getInstance().getMappingResolver().mapMethodName(
+					"official",
+					"net.minecraft.world.item.ItemStack",
+					"addAttributeTooltips",
+					remapMethodDesc(appendAttributeModifiersTooltipDescType).getDescriptor()
+			);
 
 			MethodNode appendTooltipMethod = itemStackNode.methods.stream()
 					.filter(method -> method.name.equals(methodName) && method.desc.equals(methodDesc))
 					.findAny()
-					.orElseThrow(() -> new IllegalStateException("No appendTooltip method in ItemStack"));
+					.orElseThrow(() -> new IllegalStateException("No addDetailsToTooltip method in ItemStack"));
 
 			// Search for data component accesses within this method
 			List<DataComponentType<?>> componentTypes = new ArrayList<>();
@@ -118,5 +134,45 @@ public final class VanillaTooltipProviderOrder {
 
 	public static List<DataComponentType<?>> getVanillaOrder() {
 		return VANILLA_ORDER;
+	}
+
+	private static Type remapMethodDesc(Type desc) {
+		var args = desc.getArgumentTypes();
+		var out = new Type[args.length];
+		for (int i = 0; i < args.length; i++) {
+			out[i] = unmapObjectOrArrayDesc(args[i]);
+		}
+		return Type.getMethodType(unmapObjectOrArrayDesc(desc.getReturnType()), out);
+	}
+
+	private static Type unmapObjectOrArrayDesc(Type desc) {
+		var remapper = FabricLoader.getInstance().getMappingResolver();
+		return switch (desc.getSort()) {
+			case Type.ARRAY -> {
+				var component = desc.getElementType();
+				if (component.getSort() == Type.OBJECT) {
+					yield Type.getType(
+							"[".repeat(desc.getDimensions())
+									+ "L"
+									+ remapper.unmapClassName(
+											"official",
+											component.getClassName()
+									)
+									.replace(".", "/")
+									+ ";"
+					);
+				} else yield component;
+			}
+			case Type.OBJECT -> Type.getType(
+					"L"
+							+ remapper.unmapClassName(
+									"official",
+									desc.getClassName()
+							)
+							.replace(".", "/")
+							+ ";"
+			);
+			default -> desc;
+		};
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipProviderOrder.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipProviderOrder.java
@@ -42,6 +42,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipDisplay;
 
 import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.MappingResolver;
 
 public final class VanillaTooltipProviderOrder {
 	private static final List<DataComponentType<?>> VANILLA_ORDER = scrapeVanillaOrder();
@@ -137,42 +138,47 @@ public final class VanillaTooltipProviderOrder {
 	}
 
 	private static Type remapMethodDesc(Type desc) {
-		var args = desc.getArgumentTypes();
-		var out = new Type[args.length];
+		Type[] args = desc.getArgumentTypes();
+		Type[] out = new Type[args.length];
+
 		for (int i = 0; i < args.length; i++) {
 			out[i] = unmapObjectOrArrayDesc(args[i]);
 		}
+
 		return Type.getMethodType(unmapObjectOrArrayDesc(desc.getReturnType()), out);
 	}
 
 	private static Type unmapObjectOrArrayDesc(Type desc) {
-		var remapper = FabricLoader.getInstance().getMappingResolver();
+		MappingResolver remapper = FabricLoader.getInstance().getMappingResolver();
 		return switch (desc.getSort()) {
-			case Type.ARRAY -> {
-				var component = desc.getElementType();
-				if (component.getSort() == Type.OBJECT) {
-					yield Type.getType(
-							"[".repeat(desc.getDimensions())
-									+ "L"
-									+ remapper.unmapClassName(
-											"official",
-											component.getClassName()
-									)
-									.replace(".", "/")
-									+ ";"
-					);
-				} else yield component;
+		case Type.ARRAY -> {
+			Type component = desc.getElementType();
+
+			if (component.getSort() == Type.OBJECT) {
+				yield Type.getType(
+						"[".repeat(desc.getDimensions())
+								+ "L"
+								+ remapper.unmapClassName(
+										"official",
+										component.getClassName()
+								)
+								.replace(".", "/")
+								+ ";"
+				);
+			} else {
+				yield component;
 			}
-			case Type.OBJECT -> Type.getType(
-					"L"
-							+ remapper.unmapClassName(
-									"official",
-									desc.getClassName()
-							)
-							.replace(".", "/")
-							+ ";"
-			);
-			default -> desc;
+		}
+		case Type.OBJECT -> Type.getType(
+				"L"
+						+ remapper.unmapClassName(
+								"official",
+								desc.getClassName()
+						)
+						.replace(".", "/")
+						+ ";"
+		);
+		default -> desc;
 		};
 	}
 }


### PR DESCRIPTION
undoes a change made during the port to mojmaps, allowing fapi to function in a remapped environment again