### PR TITLE
Bump CI actions to use Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v5
       - run: ./gradlew check build outJar :buildSrc:check publishToMavenLocal --stacktrace
       - uses: FabricMCBot/publish-checkstyle-report@4627c82002aa370b6cb2a3140f34c7a8c55a5297
         if: ${{ failure() }}

--- a/.github/workflows/manage_issues.yml
+++ b/.github/workflows/manage_issues.yml
@@ -8,7 +8,7 @@ jobs:
   labels:
     runs-on: ubuntu-24.04
     steps:
-      - uses: FabricMC/fabric-action-scripts@v2
+      - uses: FabricMC/fabric-action-scripts@v3
         with:
           context: ${{ github.event.action }}
           label: ${{ github.event.label.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: FabricMC/fabric-action-scripts@v2
+      - uses: FabricMC/fabric-action-scripts@v3
         id: changelog
         with:
           context: changelog


### PR DESCRIPTION
This bumps the CI to use Node 24, in preparation for the deprecation of Node 20 actions.