### PR TITLE
Fix flaky tag removal tests

### DIFF
--- a/fabric-tag-api-v1/src/testmod/java/net/fabricmc/fabric/test/tag/TagEntryRemovalTests.java
+++ b/fabric-tag-api-v1/src/testmod/java/net/fabricmc/fabric/test/tag/TagEntryRemovalTests.java
@@ -26,9 +26,6 @@ import org.slf4j.LoggerFactory;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTestHelper;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.packs.repository.PackRepository;
-import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
@@ -94,64 +91,5 @@ public final class TagEntryRemovalTests {
 				"Expected %s not to contain Unbreaking or Mending".formatted(TEST_ENCHANTMENT_TAG)
 		);
 		helper.succeed();
-	}
-
-	@GameTest
-	public void reAddRemovedValue(GameTestHelper helper) {
-		MinecraftServer server = helper.getLevel().getServer();
-
-		// Run this hook to make sure that failed runs with the 'remove_and_add_test' data pack do not error due to having it enabled.
-		removeThenTestSnowballInHappyGhastFood(helper, server);
-		addThenTestSnowballInHappyGhastFood(helper, server);
-		// Remove it again to make sure that we have a default state for other tests.
-		removeThenTestSnowballInHappyGhastFood(helper, server);
-
-		helper.succeed();
-	}
-
-	private static void removeThenTestSnowballInHappyGhastFood(GameTestHelper helper, MinecraftServer server) {
-		PackRepository repository = server.getPackRepository();
-
-		repository.removePack(TagTest.REMOVE_AND_ADD_TEST_PACK_ID.toString());
-		TagTestUtils.reloadResources(
-				helper,
-				server,
-				h -> h.assertionException("Failed to reload after removing '%s' data pack", TagTest.REMOVE_AND_ADD_TEST_PACK_ID)
-		);
-
-		TagTestUtils.assertThrows(
-				helper,
-				() -> TagTestUtils.assertTagContent(
-						helper,
-						LOGGER,
-						"",
-						server.registryAccess(),
-						List.of(ItemTags.HAPPY_GHAST_FOOD),
-						TagTestUtils::getItemKey,
-						Items.SNOWBALL
-				),
-				"Expected %s not to contain Snowball".formatted(TEST_ENCHANTMENT_TAG)
-		);
-	}
-
-	private static void addThenTestSnowballInHappyGhastFood(GameTestHelper helper, MinecraftServer server) {
-		PackRepository repository = server.getPackRepository();
-
-		repository.addPack(TagTest.REMOVE_AND_ADD_TEST_PACK_ID.toString());
-		TagTestUtils.reloadResources(
-				helper,
-				server,
-				h -> h.assertionException("Failed to reload after adding '%s' data pack", TagTest.REMOVE_AND_ADD_TEST_PACK_ID)
-		);
-
-		TagTestUtils.assertTagContent(
-				helper,
-				LOGGER,
-				"Tag {} / {} contains expected entries",
-				server.registryAccess(),
-				List.of(ItemTags.HAPPY_GHAST_FOOD),
-				TagTestUtils::getItemKey,
-				Items.SNOWBALL
-		);
 	}
 }

--- a/fabric-tag-api-v1/src/testmod/java/net/fabricmc/fabric/test/tag/TagTest.java
+++ b/fabric-tag-api-v1/src/testmod/java/net/fabricmc/fabric/test/tag/TagTest.java
@@ -27,7 +27,7 @@ import net.fabricmc.loader.api.ModContainer;
 public class TagTest implements ModInitializer {
 	public static final String MOD_ID = "fabric-tag-api-v1-testmod";
 
-	protected static final Identifier REMOVE_AND_ADD_TEST_PACK_ID = Identifier.fromNamespaceAndPath(MOD_ID, "remove_and_add_test");
+	public static final Identifier REMOVE_AND_ADD_TEST_PACK_ID = Identifier.fromNamespaceAndPath(MOD_ID, "remove_and_add_test");
 
 	@Override
 	public void onInitialize() {

--- a/fabric-tag-api-v1/src/testmod/java/net/fabricmc/fabric/test/tag/TagTestUtils.java
+++ b/fabric-tag-api-v1/src/testmod/java/net/fabricmc/fabric/test/tag/TagTestUtils.java
@@ -32,7 +32,6 @@ import net.minecraft.gametest.framework.GameTestAssertException;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
@@ -135,11 +134,5 @@ public class TagTestUtils {
 					.map(Identifier::toString)
 					.collect(Collectors.joining(", ")));
 		}
-	}
-
-	static void reloadResources(GameTestHelper helper, MinecraftServer server, Function<GameTestHelper, GameTestAssertException> onException) {
-		server.reloadResources(server.getPackRepository().getSelectedIds()).exceptionally((throwable) -> {
-			throw onException.apply(helper);
-		});
 	}
 }

--- a/fabric-tag-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/tag/client/v1/ClientTagGameTests.java
+++ b/fabric-tag-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/tag/client/v1/ClientTagGameTests.java
@@ -20,10 +20,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -37,6 +43,7 @@ import net.fabricmc.fabric.api.tag.client.v1.ClientTags;
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalBiomeTags;
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalBlockTags;
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalEnchantmentTags;
+import net.fabricmc.fabric.test.tag.TagTest;
 import net.fabricmc.fabric.test.tag.TagTestUtils;
 
 public class ClientTagGameTests implements FabricClientGameTest {
@@ -44,6 +51,7 @@ public class ClientTagGameTests implements FabricClientGameTest {
 
 	private static final TagKey<Block> REMOVAL_TEST_TAG = TagTestUtils.tagKey(Registries.BLOCK, "dirt_and_mud_with_client_exclusions");
 	private static final TagKey<Block> READD_MELONS_TEST_TAG = TagTestUtils.tagKey(Registries.BLOCK, "readd_melons");
+	private static final TagKey<Item> HAPPY_GHAST_FOOD_TAG = ItemTags.HAPPY_GHAST_FOOD;
 
 	@Override
 	public void runTest(ClientGameTestContext context) {
@@ -66,6 +74,12 @@ public class ClientTagGameTests implements FabricClientGameTest {
 			try (TestServerConnection connection = serverContext.connect()) {
 				context.runOnClient(ClientTagGameTests::clientTagDedicatedServerTests);
 				serverContext.runOnServer(ClientTagGameTests::reloadAndAddServerTagTests);
+			}
+		}
+
+		try (TestDedicatedServerContext serverContext = context.worldBuilder().createServer()) {
+			try (TestServerConnection connection = serverContext.connect()) {
+				serverContext.runOnServer(ClientTagGameTests::reAddRemovedValueTests);
 			}
 		}
 	}
@@ -147,6 +161,16 @@ public class ClientTagGameTests implements FabricClientGameTest {
 		LOGGER.info("The tests for adding tags to the server passed!");
 	}
 
+	private static void reAddRemovedValueTests(MinecraftServer server) {
+		// Run this hook to make sure that failed runs with the 'remove_and_add_test' data pack do not error due to having it enabled.
+		removeThenTestSnowballInHappyGhastFood(server);
+		addThenTestSnowballInHappyGhastFood(server);
+		// Remove it again to make sure that we have a default state for other tests.
+		removeThenTestSnowballInHappyGhastFood(server);
+
+		LOGGER.info("The tests for re-adding removed tag values passed!");
+	}
+
 	private static void removeThenTestMelonInReAddMelonsTestTag(MinecraftServer server) {
 		server.getPackRepository().removePack(ClientTagTest.ADD_BACK_MELON_PACK_ID.toString());
 		ClientTagTestUtils.reloadResources(
@@ -181,5 +205,40 @@ public class ClientTagGameTests implements FabricClientGameTest {
 				TagTestUtils::getBlockKey,
 				Blocks.MELON
 		);
+	}
+
+	private static void removeThenTestSnowballInHappyGhastFood(MinecraftServer server) {
+		server.getPackRepository().removePack(TagTest.REMOVE_AND_ADD_TEST_PACK_ID.toString());
+		ClientTagTestUtils.reloadResources(
+				server,
+				() -> new AssertionError("Failed to reload after removing '%s' data pack".formatted(TagTest.REMOVE_AND_ADD_TEST_PACK_ID))
+		);
+
+		RegistryAccess registries = server.registryAccess();
+		ClientTagTestUtils.assertThrows(
+				() -> assertSnowballInHappyGhastFood(registries),
+				"Expected %s not to contain snowball after removing pack".formatted(HAPPY_GHAST_FOOD_TAG)
+		);
+	}
+
+	private static void addThenTestSnowballInHappyGhastFood(MinecraftServer server) {
+		server.getPackRepository().addPack(TagTest.REMOVE_AND_ADD_TEST_PACK_ID.toString());
+		ClientTagTestUtils.reloadResources(
+				server,
+				() -> new AssertionError("Failed to reload after adding '%s' data pack".formatted(TagTest.REMOVE_AND_ADD_TEST_PACK_ID))
+		);
+
+		assertSnowballInHappyGhastFood(server.registryAccess());
+		LOGGER.info("Tag {} contains snowball after adding pack", HAPPY_GHAST_FOOD_TAG);
+	}
+
+	private static void assertSnowballInHappyGhastFood(RegistryAccess registries) {
+		Registry<Item> lookup = registries.lookupOrThrow(Registries.ITEM);
+		HolderSet.Named<Item> holderSet = lookup.getOrThrow(HAPPY_GHAST_FOOD_TAG);
+		boolean contains = holderSet.stream().anyMatch(h -> h.value() == Items.SNOWBALL);
+
+		if (!contains) {
+			throw new AssertionError("Expected %s to contain snowball".formatted(HAPPY_GHAST_FOOD_TAG));
+		}
 	}
 }


### PR DESCRIPTION
Reloading the resources during a game test is a recipe for disaster, tests run in parallel its never going to work nicely.