### PR TITLE
Handle extraction of permission level from non-level / custom implementations of vanilla PermissionSet (fix #5401)

### DIFF
--- a/fabric-permission-api-v1/build.gradle
+++ b/fabric-permission-api-v1/build.gradle
@@ -10,5 +10,6 @@ moduleDependencies(project, [
 
 testDependencies(project, [
 	":fabric-command-api-v2",
-	":fabric-lifecycle-events-v1"
+	":fabric-lifecycle-events-v1",
+	":fabric-networking-api-v1"
 ])

--- a/fabric-permission-api-v1/src/main/java/net/fabricmc/fabric/impl/permission/CommandPermissionContext.java
+++ b/fabric-permission-api-v1/src/main/java/net/fabricmc/fabric/impl/permission/CommandPermissionContext.java
@@ -16,20 +16,33 @@
 
 package net.fabricmc.fabric.impl.permission;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import com.mojang.datafixers.util.Pair;
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.permissions.LevelBasedPermissionSet;
+import net.minecraft.server.permissions.Permission;
 import net.minecraft.server.permissions.PermissionLevel;
+import net.minecraft.server.permissions.PermissionSet;
+import net.minecraft.server.permissions.Permissions;
 
 import net.fabricmc.fabric.api.permission.v1.PermissionContext;
 
 public class CommandPermissionContext implements PermissionContext {
+	private static final List<Pair<PermissionLevel, Permission>> PERMISSION_LEVEL_CHECKS = List.of(
+			Pair.of(PermissionLevel.MODERATORS, Permissions.COMMANDS_MODERATOR),
+			Pair.of(PermissionLevel.GAMEMASTERS, Permissions.COMMANDS_GAMEMASTER),
+			Pair.of(PermissionLevel.ADMINS, Permissions.COMMANDS_ADMIN),
+			Pair.of(PermissionLevel.OWNERS, Permissions.COMMANDS_OWNER)
+	);
+
 	private final CommandSourceStack source;
+	private @Nullable PermissionLevel permissionLevel;
 
 	public CommandPermissionContext(CommandSourceStack source) {
 		this.source = source;
@@ -59,7 +72,35 @@ public class CommandPermissionContext implements PermissionContext {
 
 	@Override
 	public PermissionLevel permissionLevel() {
-		return this.source.permissions() instanceof LevelBasedPermissionSet levelBasedPermissionSet ? levelBasedPermissionSet.level() : PermissionLevel.ALL;
+		if (this.permissionLevel == null) {
+			this.permissionLevel = extractPermissionLevel(this.source.permissions());
+		}
+
+		return this.permissionLevel;
+	}
+
+	public static PermissionLevel extractPermissionLevel(PermissionSet permissions) {
+		if (permissions instanceof LevelBasedPermissionSet levelBasedPermissionSet) {
+			return levelBasedPermissionSet.level();
+		} else if (permissions == PermissionSet.ALL_PERMISSIONS) {
+			return PermissionLevel.OWNERS;
+		} else if (permissions == PermissionSet.NO_PERMISSIONS) {
+			return PermissionLevel.ALL;
+		}
+
+		PermissionLevel level = PermissionLevel.ALL;
+
+		// Search for closest permission level, starting from the lowest to highest.
+		// Not the ideal solution, but should handle any custom PermissionSet implementation.
+		for (Pair<PermissionLevel, Permission> pair : PERMISSION_LEVEL_CHECKS) {
+			if (!permissions.hasPermission(pair.getSecond())) {
+				break;
+			}
+
+			level = pair.getFirst();
+		}
+
+		return level;
 	}
 
 	@Override

--- a/fabric-permission-api-v1/src/main/java/net/fabricmc/fabric/impl/permission/EntityPermissionContext.java
+++ b/fabric-permission-api-v1/src/main/java/net/fabricmc/fabric/impl/permission/EntityPermissionContext.java
@@ -23,7 +23,6 @@ import org.jspecify.annotations.Nullable;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.permissions.LevelBasedPermissionSet;
 import net.minecraft.server.permissions.PermissionLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -35,6 +34,7 @@ public class EntityPermissionContext implements PermissionContext {
 	private final Type type;
 	private final Set<Key<?>> keys;
 	private final @Nullable MinecraftServer server;
+	private @Nullable PermissionLevel permissionLevel;
 
 	public EntityPermissionContext(Entity entity) {
 		this.entity = entity;
@@ -79,9 +79,11 @@ public class EntityPermissionContext implements PermissionContext {
 
 	@Override
 	public PermissionLevel permissionLevel() {
-		return entity instanceof Player player && player.permissions() instanceof LevelBasedPermissionSet levelBasedPermissionSet
-				? levelBasedPermissionSet.level()
-				: PermissionLevel.ALL;
+		if (this.permissionLevel == null) {
+			this.permissionLevel = this.entity instanceof Player player ? CommandPermissionContext.extractPermissionLevel(player.permissions()) : PermissionLevel.ALL;
+		}
+
+		return this.permissionLevel;
 	}
 
 	@Override

--- a/fabric-permission-api-v1/src/testmod/java/net/fabricmc/fabric/test/permission/PermissionTestMod.java
+++ b/fabric-permission-api-v1/src/testmod/java/net/fabricmc/fabric/test/permission/PermissionTestMod.java
@@ -43,6 +43,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.server.permissions.PermissionLevel;
 import net.minecraft.server.players.NameAndId;
 import net.minecraft.util.RandomSource;
@@ -53,6 +54,8 @@ import net.minecraft.world.level.block.Blocks;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.permission.v1.MutablePermissionContext;
 import net.fabricmc.fabric.api.permission.v1.PermissionContext;
 import net.fabricmc.fabric.api.permission.v1.PermissionEvents;
@@ -80,6 +83,7 @@ public class PermissionTestMod implements ModInitializer, PermissionEvents.OnReq
 
 		this.runBasicTest();
 		ServerLifecycleEvents.SERVER_STARTED.register(this::runServerTest);
+		ServerPlayConnectionEvents.JOIN.register(this::runPlayerTest);
 	}
 
 	private void runBasicTest() {
@@ -111,6 +115,17 @@ public class PermissionTestMod implements ModInitializer, PermissionEvents.OnReq
 				throw new IllegalStateException("Permission check failed! valueMainCheck != value, d=" + (valueMainCheck - value));
 			}
 		}, server);
+	}
+
+	@SuppressWarnings("ConstantValue")
+	private void runPlayerTest(ServerGamePacketListenerImpl listener, PacketSender packetSender, MinecraftServer server) {
+		if (listener.player.getPermissionContext().permissionLevel() == null) {
+			throw new IllegalStateException("Player entity permission level is null!");
+		}
+
+		if (listener.player.createCommandSourceStack().getPermissionContext().permissionLevel() == null) {
+			throw new IllegalStateException("Player command source permission level is null!");
+		}
 	}
 
 	private void registerCommands(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext context, Commands.CommandSelection selection) {


### PR DESCRIPTION
Pretty much just a fix for #5401.

The PermissionLevel is handled lazily as both command and entity one are handled too early to receive the PermissionSet.