### PR TITLE
Add `fabric:false` resource condition

### DIFF
--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/gold_ingot.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/misc/gold_ingot.json
@@ -1,10 +1,7 @@
 {
   "fabric:load_conditions": [
     {
-      "condition": "fabric:not",
-      "value": {
-        "condition": "fabric:true"
-      }
+      "condition": "fabric:false"
     }
   ],
   "parent": "minecraft:recipes/root",

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/test/root_not_loaded.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/test/root_not_loaded.json
@@ -1,10 +1,7 @@
 {
   "fabric:load_conditions": [
     {
-      "condition": "fabric:not",
-      "value": {
-        "condition": "fabric:true"
-      }
+      "condition": "fabric:false"
     }
   ],
   "criteria": {

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/loot_table/blocks/simple_block.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/loot_table/blocks/simple_block.json
@@ -3,10 +3,7 @@
     {
       "condition": "fabric:not",
       "value": {
-        "condition": "fabric:not",
-        "value": {
-          "condition": "fabric:true"
-        }
+        "condition": "fabric:false"
       }
     },
     {

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/loot_table/entities/simple_entity.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/loot_table/entities/simple_entity.json
@@ -3,10 +3,7 @@
     {
       "condition": "fabric:not",
       "value": {
-        "condition": "fabric:not",
-        "value": {
-          "condition": "fabric:true"
-        }
+        "condition": "fabric:false"
       }
     },
     {

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/recipe/gold_ingot.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/recipe/gold_ingot.json
@@ -1,10 +1,7 @@
 {
   "fabric:load_conditions": [
     {
-      "condition": "fabric:not",
-      "value": {
-        "condition": "fabric:true"
-      }
+      "condition": "fabric:false"
     }
   ],
   "type": "minecraft:crafting_shapeless",

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -105,7 +105,7 @@ import net.fabricmc.loader.api.FabricLoader;
 
 public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 	private static final ResourceCondition ALWAYS_LOADED = ResourceConditions.alwaysTrue();
-	private static final ResourceCondition NEVER_LOADED = ResourceConditions.not(ALWAYS_LOADED);
+	private static final ResourceCondition NEVER_LOADED = ResourceConditions.alwaysFalse();
 
 	@Override
 	public void addJsonKeySortOrders(JsonKeySortOrderCallback callback) {

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ResourceConditions.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/api/resource/conditions/v1/ResourceConditions.java
@@ -30,6 +30,7 @@ import net.minecraft.world.flag.FeatureFlag;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.AllModsLoadedResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.AndResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.AnyModsLoadedResourceCondition;
+import net.fabricmc.fabric.impl.resource.conditions.conditions.FalseResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.FeaturesEnabledResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.NotResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.OrResourceCondition;
@@ -81,6 +82,13 @@ public final class ResourceConditions {
 	 */
 	public static ResourceCondition alwaysTrue() {
 		return new TrueResourceCondition();
+	}
+
+	/**
+	 * A condition that always passes. Has ID {@code fabric:false}.
+	 */
+	public static ResourceCondition alwaysFalse() {
+		return new FalseResourceCondition();
 	}
 
 	/**

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/DefaultResourceConditionTypes.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/DefaultResourceConditionTypes.java
@@ -25,6 +25,7 @@ import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditionType;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.AllModsLoadedResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.AndResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.AnyModsLoadedResourceCondition;
+import net.fabricmc.fabric.impl.resource.conditions.conditions.FalseResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.FeaturesEnabledResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.NotResourceCondition;
 import net.fabricmc.fabric.impl.resource.conditions.conditions.OrResourceCondition;
@@ -34,6 +35,7 @@ import net.fabricmc.fabric.impl.resource.conditions.conditions.TrueResourceCondi
 
 public class DefaultResourceConditionTypes {
 	public static final ResourceConditionType<TrueResourceCondition> TRUE = createResourceConditionType("true", TrueResourceCondition.CODEC);
+	public static final ResourceConditionType<FalseResourceCondition> FALSE = createResourceConditionType("false", FalseResourceCondition.CODEC);
 	public static final ResourceConditionType<NotResourceCondition> NOT = createResourceConditionType("not", NotResourceCondition.CODEC);
 	public static final ResourceConditionType<OrResourceCondition> OR = createResourceConditionType("or", OrResourceCondition.CODEC);
 	public static final ResourceConditionType<AndResourceCondition> AND = createResourceConditionType("and", AndResourceCondition.CODEC);

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/ResourceConditionsImpl.java
@@ -50,6 +50,7 @@ public final class ResourceConditionsImpl implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		ResourceConditions.register(DefaultResourceConditionTypes.TRUE);
+		ResourceConditions.register(DefaultResourceConditionTypes.FALSE);
 		ResourceConditions.register(DefaultResourceConditionTypes.NOT);
 		ResourceConditions.register(DefaultResourceConditionTypes.AND);
 		ResourceConditions.register(DefaultResourceConditionTypes.OR);

--- a/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/conditions/FalseResourceCondition.java
+++ b/fabric-resource-conditions-api-v1/src/main/java/net/fabricmc/fabric/impl/resource/conditions/conditions/FalseResourceCondition.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.resource.conditions.conditions;
+
+import com.mojang.serialization.MapCodec;
+import org.jspecify.annotations.Nullable;
+
+import net.minecraft.resources.RegistryOps;
+
+import net.fabricmc.fabric.api.resource.conditions.v1.ResourceCondition;
+import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditionType;
+import net.fabricmc.fabric.impl.resource.conditions.DefaultResourceConditionTypes;
+
+public class FalseResourceCondition implements ResourceCondition {
+	public static final MapCodec<FalseResourceCondition> CODEC = MapCodec.unit(FalseResourceCondition::new);
+
+	@Override
+	public ResourceConditionType<?> getType() {
+		return DefaultResourceConditionTypes.FALSE;
+	}
+
+	@Override
+	public boolean test(RegistryOps.@Nullable RegistryInfoLookup registryInfo) {
+		return false;
+	}
+}

--- a/fabric-resource-conditions-api-v1/src/test/java/net/fabricmc/fabric/test/resource/conditions/ResourceConditionsUnitTest.java
+++ b/fabric-resource-conditions-api-v1/src/test/java/net/fabricmc/fabric/test/resource/conditions/ResourceConditionsUnitTest.java
@@ -64,7 +64,7 @@ public class ResourceConditionsUnitTest {
 	@Test
 	public void logics() {
 		ResourceCondition alwaysTrue = ResourceConditions.alwaysTrue();
-		ResourceCondition alwaysFalse = ResourceConditions.not(alwaysTrue);
+		ResourceCondition alwaysFalse = ResourceConditions.alwaysFalse();
 		ResourceCondition trueAndTrue = ResourceConditions.and(alwaysTrue, alwaysTrue);
 		ResourceCondition trueAndFalse = ResourceConditions.and(alwaysTrue, alwaysFalse);
 		ResourceCondition emptyAnd = ResourceConditions.and();


### PR DESCRIPTION
Adds an equivalent to `fabric:true` that never passes, useful for quickly unloading resources like unwanted recipes or advancements. This is already possible by chaining `fabric:not` with `fabric:true`, but that is quite longwinded when manually updating JSON (e.g. modpacks), and having an obvious `false` is preferred. Uses of `fabric:not` when applied to `fabric:true` in data generation tests have been updated to use `fabric:false`.