### PR TITLE
Delay dedicated server start until after ServerLifecycleEvents.SERVER_STARTED

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/MinecraftServerHooks.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/impl/event/lifecycle/MinecraftServerHooks.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.event.lifecycle;
+
+public interface MinecraftServerHooks {
+	boolean fabric$isStartupReady();
+}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.notifications.NotificationManager;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -45,6 +46,10 @@ import net.fabricmc.fabric.impl.event.lifecycle.MinecraftServerHooks;
 public abstract class MinecraftServerMixin implements MinecraftServerHooks {
 	@Shadow
 	private MinecraftServer.ReloadableResources resources;
+
+	@Shadow
+	public abstract NotificationManager notificationManager();
+
 	@Unique
 	protected final AtomicBoolean startupReady = new AtomicBoolean(false);
 
@@ -124,7 +129,7 @@ public abstract class MinecraftServerMixin implements MinecraftServerHooks {
 	@Unique
 	protected void afterServerStartedEvent() {
 		if (this.startupReady.getAndSet(true)) {
-			throw new IllegalStateException();
+			throw new IllegalStateException("Fabric: Server is already marked as started");
 		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -46,7 +46,7 @@ public abstract class MinecraftServerMixin implements MinecraftServerHooks {
 	@Shadow
 	private MinecraftServer.ReloadableResources resources;
 	@Unique
-	protected final AtomicBoolean fabric$startupReady = new AtomicBoolean(false);
+	protected final AtomicBoolean startupReady = new AtomicBoolean(false);
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;initServer()Z"), method = "runServer")
 	private void beforeSetupServer(CallbackInfo info) {
@@ -118,12 +118,12 @@ public abstract class MinecraftServerMixin implements MinecraftServerHooks {
 
 	@Override
 	public boolean fabric$isStartupReady() {
-		return this.fabric$startupReady.get();
+		return this.startupReady.get();
 	}
 
 	@Unique
 	protected void afterServerStartedEvent() {
-		if (this.fabric$startupReady.getAndSet(true)) {
+		if (this.startupReady.getAndSet(true)) {
 			throw new IllegalStateException();
 		}
 	}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.mixin.event.lifecycle;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
@@ -26,6 +27,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -37,11 +39,14 @@ import net.minecraft.server.level.ServerLevel;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLevelEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.impl.event.lifecycle.MinecraftServerHooks;
 
 @Mixin(MinecraftServer.class)
-public abstract class MinecraftServerMixin {
+public abstract class MinecraftServerMixin implements MinecraftServerHooks {
 	@Shadow
 	private MinecraftServer.ReloadableResources resources;
+	@Unique
+	protected final AtomicBoolean fabric$startupReady = new AtomicBoolean(false);
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;initServer()Z"), method = "runServer")
 	private void beforeSetupServer(CallbackInfo info) {
@@ -51,6 +56,7 @@ public abstract class MinecraftServerMixin {
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;buildServerStatus()Lnet/minecraft/network/protocol/status/ServerStatus;", ordinal = 0), method = "runServer")
 	private void afterSetupServer(CallbackInfo info) {
 		ServerLifecycleEvents.SERVER_STARTED.invoker().onServerStarted((MinecraftServer) (Object) this);
+		afterServerStartedEvent();
 	}
 
 	@Inject(at = @At("HEAD"), method = "stopServer")
@@ -108,5 +114,17 @@ public abstract class MinecraftServerMixin {
 	@Inject(method = "saveAllChunks", at = @At("TAIL"))
 	private void endSave(boolean suppressLogs, boolean flush, boolean force, CallbackInfoReturnable<Boolean> cir) {
 		ServerLifecycleEvents.AFTER_SAVE.invoker().onAfterSave((MinecraftServer) (Object) this, flush, force);
+	}
+
+	@Override
+	public boolean fabric$isStartupReady() {
+		return this.fabric$startupReady.get();
+	}
+
+	@Unique
+	protected void afterServerStartedEvent() {
+		if (this.fabric$startupReady.getAndSet(true)) {
+			throw new IllegalStateException();
+		}
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/DedicatedServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/DedicatedServerMixin.java
@@ -16,55 +16,27 @@
 
 package net.fabricmc.fabric.mixin.event.lifecycle.server;
 
-import java.util.Locale;
-
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import org.objectweb.asm.Opcodes;
-import org.slf4j.Logger;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.Slice;
 
 import net.minecraft.server.dedicated.DedicatedServer;
-import net.minecraft.util.Util;
+import net.minecraft.server.notifications.NotificationManager;
 
 import net.fabricmc.fabric.mixin.event.lifecycle.MinecraftServerMixin;
 
 @Mixin(DedicatedServer.class)
 public abstract class DedicatedServerMixin extends MinecraftServerMixin {
-	@Shadow
-	@Final
-	private static Logger LOGGER;
-	@Unique
-	private long levelNanoTime = Long.MIN_VALUE;
-
-	@WrapOperation(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;getNanos()J"), slice = @Slice(to = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/UserNameToIdResolver;resolveOfflineUsers(Z)V")))
-	private long captureDoneLogStartNanos(Operation<Long> original) {
-		return this.levelNanoTime = original.call();
-	}
-
-	@Redirect(method = "initServer", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;info(Ljava/lang/String;Ljava/lang/Object;)V"), slice = @Slice(from = @At(value = "INVOKE", target = "Ljava/lang/String;format(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;"), to = @At(value = "FIELD", target = "Lnet/minecraft/server/dedicated/DedicatedServerProperties;announcePlayerAchievements:Ljava/lang/Boolean;", opcode = Opcodes.GETFIELD)))
-	private void deferDoneLog(Logger logger, String message, Object arg) {
-		// Delay the dedicated server's readiness log until after ServerLifecycleEvents.SERVER_STARTED has been fired.
+	@Redirect(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/notifications/NotificationManager;serverStarted()V"))
+	private void deferServerStartedNotification(NotificationManager instance) {
+		// Delay the JSON RPC server started notification until the ServerLifecycleEvents.SERVER_STARTED event is fired.
 	}
 
 	@Unique
 	@Override
 	public void afterServerStartedEvent() {
 		super.afterServerStartedEvent();
-
-		if (this.levelNanoTime == Long.MIN_VALUE) {
-			throw new IllegalStateException();
-		}
-
-		double elapsed = Util.getNanos() - levelNanoTime;
-		String time = String.format(Locale.ROOT, "%.3fs", elapsed / 1.0E9);
-		LOGGER.info("Done ({})! For help, type \"help\"", time);
-		this.levelNanoTime = Long.MIN_VALUE;
+		this.notificationManager().serverStarted();
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/DedicatedServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/DedicatedServerMixin.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.event.lifecycle.server;
+
+import java.util.Locale;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.objectweb.asm.Opcodes;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.util.Util;
+
+import net.fabricmc.fabric.mixin.event.lifecycle.MinecraftServerMixin;
+
+@Mixin(DedicatedServer.class)
+public abstract class DedicatedServerMixin extends MinecraftServerMixin {
+	@Shadow
+	@Final
+	private static Logger LOGGER;
+	@Unique
+	private long levelNanoTime = Long.MIN_VALUE;
+
+	@WrapOperation(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;getNanos()J"), slice = @Slice(to = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/UserNameToIdResolver;resolveOfflineUsers(Z)V")))
+	private long captureDoneLogStartNanos(Operation<Long> original) {
+		return this.levelNanoTime = original.call();
+	}
+
+	@Redirect(method = "initServer", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;info(Ljava/lang/String;Ljava/lang/Object;)V"), slice = @Slice(from = @At(value = "INVOKE", target = "Ljava/lang/String;format(Ljava/util/Locale;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;"), to = @At(value = "FIELD", target = "Lnet/minecraft/server/dedicated/DedicatedServerProperties;announcePlayerAchievements:Ljava/lang/Boolean;", opcode = Opcodes.GETFIELD)))
+	private void deferDoneLog(Logger logger, String message, Object arg) {
+		// Delay the dedicated server's readiness log until after ServerLifecycleEvents.SERVER_STARTED has been fired.
+	}
+
+	@Unique
+	@Override
+	public void afterServerStartedEvent() {
+		super.afterServerStartedEvent();
+
+		if (this.levelNanoTime == Long.MIN_VALUE) {
+			throw new IllegalStateException();
+		}
+
+		double elapsed = Util.getNanos() - levelNanoTime;
+		String time = String.format(Locale.ROOT, "%.3fs", elapsed / 1.0E9);
+		LOGGER.info("Done ({})! For help, type \"help\"", time);
+		this.levelNanoTime = Long.MIN_VALUE;
+	}
+}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/ServerHandshakePacketListenerImplMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/server/ServerHandshakePacketListenerImplMixin.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.event.lifecycle.server;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.network.Connection;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.handshake.ClientIntentionPacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerHandshakePacketListenerImpl;
+
+import net.fabricmc.fabric.impl.event.lifecycle.MinecraftServerHooks;
+
+@Mixin(ServerHandshakePacketListenerImpl.class)
+public abstract class ServerHandshakePacketListenerImplMixin {
+	@Unique
+	private static final Component STARTUP_DISCONNET_REASON = Component.literal("Server is still starting!");
+
+	@Shadow
+	@Final
+	private Connection connection;
+	@Shadow
+	@Final
+	private MinecraftServer server;
+
+	@Unique
+	private boolean hasBecomeReady = false;
+
+	// Reject connections untill after ServerLifecycleEvents.SERVER_STARTED has been fired
+	@Inject(method = "handleIntention", at = @At("HEAD"), cancellable = true)
+	private void rejectConnectionsDuringStartup(ClientIntentionPacket packet, CallbackInfo ci) {
+		if (hasBecomeReady) {
+			return;
+		}
+
+		if (!this.server.isDedicatedServer() || this.connection.isMemoryConnection() || ((MinecraftServerHooks) this.server).fabric$isStartupReady()) {
+			hasBecomeReady = true;
+			return;
+		}
+
+		this.connection.disconnect(STARTUP_DISCONNET_REASON);
+		ci.cancel();
+	}
+}

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
@@ -18,7 +18,9 @@
     "ServerLevelMixin"
   ],
   "server": [
-    "server.LevelChunkMixin"
+    "server.DedicatedServerMixin",
+    "server.LevelChunkMixin",
+    "server.ServerHandshakePacketListenerImplMixin"
   ],
   "injectors": {
     "defaultRequire": 1,

--- a/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerLifecycleTests.java
+++ b/fabric-lifecycle-events-v1/src/testmod/java/net/fabricmc/fabric/test/event/lifecycle/ServerLifecycleTests.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.event.lifecycle;
 
+import java.time.Duration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,10 +30,21 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
  */
 public final class ServerLifecycleTests implements ModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger("LifecycleEventsTest");
+	private static final boolean SLOW_START_TEST = Boolean.getBoolean("fabric-lifecycle-events-v1.test.slow-start");
 
 	@Override
 	public void onInitialize() {
 		ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+			if (SLOW_START_TEST) {
+				LOGGER.info("Simulating slow server start...");
+
+				try {
+					Thread.sleep(Duration.ofSeconds(10));
+				} catch (InterruptedException e) {
+					LOGGER.warn("Sleep was interrupted", e);
+				}
+			}
+
 			LOGGER.info("Started Server!");
 		});
 


### PR DESCRIPTION
This fixes a possible race condition where a player may start logging in before the ServerLifecycleEvents.SERVER_STARTED event has been fired. Mods often load world specific configuration during this event.

The JSON RPC server started notification has also been moved later.