### PR TITLE
Add FabricClientCommandSource#attended() to require confirmation for privileged client commands.

### DIFF
--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/ClientCommands.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/ClientCommands.java
@@ -50,6 +50,10 @@ import net.fabricmc.fabric.impl.command.client.ClientCommandInternals;
  * The aim is to make commands from the server take precedence over client-sided commands
  * in a future version of this API.
  *
+ * <p>Commands that may perform destructive or privileged operations should generally
+ * require {@link FabricClientCommandSource#attended()} so they only run when explicitly
+ * entered by the user, and not when triggered from a server-provided text component.
+ *
  * <h2>Example command</h2>
  * <pre>
  * {@code

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/FabricClientCommandSource.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/api/client/command/v2/FabricClientCommandSource.java
@@ -104,4 +104,18 @@ public interface FabricClientCommandSource extends SharedSuggestionProvider {
 	default @Nullable Object getMeta(String key) {
 		return null;
 	}
+
+	/**
+	 * Returns whether the command was explicitly entered by the user.
+	 *
+	 * <p>This should be used for commands that may perform destructive or
+	 * privileged operations, so they can require direct user intent via
+	 * {@code .requires(FabricClientCommandSource::attended)}.
+	 *
+	 * <p>This is {@code false} when the command is invoked via a text
+	 * component from the server.
+	 *
+	 * @return whether the command execution is attended
+	 */
+	boolean attended();
 }

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
@@ -40,7 +40,11 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.ConfirmScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentUtils;
 import net.minecraft.network.protocol.game.ClientboundCommandsPacket;
@@ -48,6 +52,7 @@ import net.minecraft.util.profiling.Profiler;
 
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.mixin.command.HelpCommandAccessor;
+import net.fabricmc.fabric.mixin.command.client.ClientPacketListenerAccessor;
 
 public final class ClientCommandInternals {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ClientCommandInternals.class);
@@ -67,19 +72,27 @@ public final class ClientCommandInternals {
 	 * Executes a client-sided command. Callers should ensure that this is only called
 	 * on slash-prefixed messages and the slash needs to be removed before calling.
 	 *
+	 * <p>If the command is ran "unattended" (e.g. from a text component click event) and the command requires the attended permissions, a confirmation screen will be displayed before executing the command.
+	 *
 	 * @param command the command with slash removed
+	 * @param source the command source to execute the command with
+	 * @param restrictedSource a command source with more restricted permissions than {@code source} to check if the command requires confirmation. Null when command is ran directly with user input.
 	 * @return true if the command should not be sent to the server, false otherwise
 	 */
-	public static boolean executeCommand(String command) {
-		Minecraft instance = Minecraft.getInstance();
-
-		// The interface is implemented on ClientSuggestionProvider with a mixin.
-		// noinspection ConstantConditions
-		FabricClientCommandSource source = (FabricClientCommandSource) instance.getConnection().getSuggestionsProvider();
-
+	public static boolean executeCommand(String command, FabricClientCommandSource source, @Nullable FabricClientCommandSource restrictedSource) {
 		Profiler.get().push(command);
 
 		try {
+			if (restrictedSource != null) {
+				if (requiresConfirmation(command, source, restrictedSource)) {
+					openSendConfirmationWindow(command, "multiplayer.confirm_command.permissions_required", () -> {
+						executeCommand(command, source, null);
+					});
+
+					return true;
+				}
+			}
+
 			// TODO: Check for server commands before executing.
 			//   This requires parsing the command, checking if they match a server command
 			//   and then executing the command with the parse results.
@@ -103,6 +116,43 @@ public final class ClientCommandInternals {
 		} finally {
 			Profiler.get().pop();
 		}
+	}
+
+	private static boolean requiresConfirmation(String command, FabricClientCommandSource source, FabricClientCommandSource restrictedSource) {
+		ParseResults<FabricClientCommandSource> parseResults = activeDispatcher.parse(command, source);
+
+		if (!ClientPacketListenerAccessor.invokeIsValidCommand(parseResults)) {
+			// not a valid command, no need to confirm
+			return false;
+		}
+
+		parseResults = activeDispatcher.parse(command, restrictedSource);
+
+		if (!ClientPacketListenerAccessor.invokeIsValidCommand(parseResults)) {
+			// We failed to parse the command with the restricted permissions, thus it means that the command requires user confirmation before being executed.
+			return true;
+		}
+
+		return false;
+	}
+
+	private static void openSendConfirmationWindow(final String command, final String messageKey, final Runnable onAccept) {
+		Minecraft minecraft = Minecraft.getInstance();
+		Screen currentScreen = minecraft.gui.screen();
+		var confirmScreen = new ConfirmScreen(
+				result -> {
+					if (result) {
+						onAccept.run();
+					}
+
+					minecraft.gui.setScreen(currentScreen);
+				},
+				Component.translatable("multiplayer.confirm_command.title"),
+				Component.translatable("multiplayer.confirm_command.permissions_required", Component.literal(command).withStyle(ChatFormatting.YELLOW)),
+				Component.translatable("multiplayer.confirm_command.run_command"),
+				currentScreen != null ? CommonComponents.GUI_BACK : CommonComponents.GUI_CANCEL
+		);
+		minecraft.gui.setScreen(confirmScreen);
 	}
 
 	/**

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientSuggestionProviderExtensions.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientSuggestionProviderExtensions.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.command.client;
+
+public interface ClientSuggestionProviderExtensions {
+	void fabric_markAttended();
+}

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerAccessor.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerAccessor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.command.client;
+
+import com.mojang.brigadier.ParseResults;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.client.multiplayer.ClientPacketListener;
+
+@Mixin(ClientPacketListener.class)
+public interface ClientPacketListenerAccessor {
+	@Invoker
+	static boolean invokeIsValidCommand(final ParseResults<?> parseResults) {
+		throw new AssertionError();
+	}
+}

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
@@ -26,12 +26,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.multiplayer.ClientSuggestionProvider;
+import net.minecraft.client.multiplayer.CommonListenerCookie;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundCommandsPacket;
 import net.minecraft.network.protocol.game.ClientboundLoginPacket;
 import net.minecraft.world.flag.FeatureFlagSet;
@@ -39,6 +42,7 @@ import net.minecraft.world.flag.FeatureFlagSet;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.impl.command.client.ClientCommandInternals;
+import net.fabricmc.fabric.impl.command.client.ClientSuggestionProviderExtensions;
 
 @Mixin(ClientPacketListener.class)
 abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastReceivedCommandsPacketAccessor {
@@ -48,6 +52,10 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 	@Shadow
 	@Final
 	private ClientSuggestionProvider suggestionsProvider;
+
+	@Shadow
+	@Final
+	private ClientSuggestionProvider restrictedSuggestionsProvider;
 
 	@Final
 	@Shadow
@@ -59,6 +67,11 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 
 	@Unique
 	private @Nullable ClientboundCommandsPacket lastReceivedCommandsPacket = null;
+
+	@Inject(method = "<init>", at = @At("RETURN"))
+	private void init(Minecraft minecraft, Connection connection, CommonListenerCookie cookie, CallbackInfo ci) {
+		((ClientSuggestionProviderExtensions) this.suggestionsProvider).fabric_markAttended();
+	}
 
 	@Inject(method = "handleLogin", at = @At("RETURN"))
 	private void onGameJoin(ClientboundLoginPacket packet, CallbackInfo info) {
@@ -84,14 +97,14 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 
 	@Inject(method = "sendUnattendedCommand", at = @At("HEAD"), cancellable = true)
 	private void onSendCommand(String command, Screen screen, CallbackInfo info) {
-		if (ClientCommandInternals.executeCommand(command)) {
+		if (ClientCommandInternals.executeCommand(command, (FabricClientCommandSource) suggestionsProvider, (FabricClientCommandSource) restrictedSuggestionsProvider)) {
 			info.cancel();
 		}
 	}
 
 	@Inject(method = "sendCommand", at = @At("HEAD"), cancellable = true)
 	private void onSendCommand(String command, CallbackInfo info) {
-		if (ClientCommandInternals.executeCommand(command)) {
+		if (ClientCommandInternals.executeCommand(command, (FabricClientCommandSource) suggestionsProvider, null)) {
 			info.cancel();
 		}
 	}

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientSuggestionProviderMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientSuggestionProviderMixin.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.mixin.command.client;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -28,12 +29,16 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.fabricmc.fabric.impl.command.client.ClientSuggestionProviderExtensions;
 
 @Mixin(ClientSuggestionProvider.class)
-abstract class ClientSuggestionProviderMixin implements FabricClientCommandSource {
+abstract class ClientSuggestionProviderMixin implements FabricClientCommandSource, ClientSuggestionProviderExtensions {
 	@Shadow
 	@Final
 	private Minecraft minecraft;
+
+	@Unique
+	private boolean attended = false;
 
 	@Override
 	public void sendFeedback(Component message) {
@@ -59,5 +64,15 @@ abstract class ClientSuggestionProviderMixin implements FabricClientCommandSourc
 	@Override
 	public ClientLevel getLevel() {
 		return minecraft.level;
+	}
+
+	@Override
+	public boolean attended() {
+		return attended;
+	}
+
+	@Override
+	public void fabric_markAttended() {
+		this.attended = true;
 	}
 }

--- a/fabric-command-api-v2/src/client/resources/fabric-command-api-v2.client.mixins.json
+++ b/fabric-command-api-v2/src/client/resources/fabric-command-api-v2.client.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.command.client",
   "compatibilityLevel": "JAVA_25",
   "client": [
+    "ClientPacketListenerAccessor",
     "ClientSuggestionProviderMixin",
     "ClientPacketListenerMixin"
   ],

--- a/fabric-command-api-v2/src/testmodClient/java/net/fabricmc/fabric/test/command/client/ClientCommandTest.java
+++ b/fabric-command-api-v2/src/testmodClient/java/net/fabricmc/fabric/test/command/client/ClientCommandTest.java
@@ -29,6 +29,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientSuggestionProvider;
 import net.minecraft.commands.arguments.item.ItemArgument;
 import net.minecraft.commands.arguments.item.ItemInput;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 
 import net.fabricmc.api.ClientModInitializer;
@@ -115,6 +116,16 @@ public final class ClientCommandTest implements ClientModInitializer {
 				}
 
 				return Command.SINGLE_SUCCESS;
+			}));
+
+			dispatcher.register(ClientCommands.literal("test_client_command_confirmation").requires(FabricClientCommandSource::attended).executes(context -> {
+				context.getSource().sendFeedback(Component.literal("This command required user ineraction"));
+				return 0;
+			}));
+
+			dispatcher.register(ClientCommands.literal("test_client_command_confirmation_trigger").executes(context -> {
+				context.getSource().sendFeedback(Component.literal("[Run Command]").withStyle(style -> style.withClickEvent(new ClickEvent.RunCommand("/test_client_command_confirmation"))));
+				return 0;
 			}));
 
 			// Tests


### PR DESCRIPTION
This PR adds `.requires(FabricClientCommandSource::attended)` to client commands, allowing mods to ensure that the user has confirmed that they expect run the given client command.  Without this the server could provide a text component with a command click even to run a client command without the user being able to see the command. While I dont think this is a security flaw in FAPI (as there are many ways to shoot yourself in the foot) I think it may be nice to provide an easy to use API to allow mods to ask for confirmation. Something they could and should have been doing before this PR.


https://github.com/user-attachments/assets/9b0dcc02-a5f2-4612-b764-c680254aa825

