### PR TITLE
Fix warning about LevelExtractor missing resource reload id.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ def debugArgs = [
 	"-Dmixin.debug.verify=true",
 	//"-Dmixin.debug.strict=true",
 	"-Dmixin.debug.countInjections=true",
+	"-Dfabric.resource_loader.debug.reloaders_identity.strict=true",
 	"-XX:+UseZGC",
 	"-XX:+UseCompactObjectHeaders",
 	"-XX:+AlwaysPreTouch",

--- a/fabric-resource-loader-v1/src/client/java/net/fabricmc/fabric/mixin/resource/client/KeyedClientResourceReloadListenerMixin.java
+++ b/fabric-resource-loader-v1/src/client/java/net/fabricmc/fabric/mixin/resource/client/KeyedClientResourceReloadListenerMixin.java
@@ -30,6 +30,7 @@ import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.ShaderManager;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.client.renderer.extract.LevelExtractor;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.resources.DryFoliageColorReloadListener;
 import net.minecraft.client.resources.FoliageColorReloadListener;
@@ -66,7 +67,7 @@ import net.fabricmc.fabric.impl.resource.FabricResourceReloader;
 		TextureManager.class,
 		WaypointStyleManager.class,
 		/* private */
-		LevelRenderer.class, GpuWarnlistManager.class, PeriodicNotificationManager.class
+		LevelRenderer.class, LevelExtractor.class, GpuWarnlistManager.class, PeriodicNotificationManager.class
 })
 public abstract class KeyedClientResourceReloadListenerMixin implements FabricResourceReloader {
 	@Unique

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/ResourceLoaderImpl.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/ResourceLoaderImpl.java
@@ -64,8 +64,9 @@ public sealed class ResourceLoaderImpl implements ResourceLoader permits DataRes
 	private static final Map<PackType, ResourceLoaderImpl> IMPL_MAP = new EnumMap<>(PackType.class);
 	private static final Set<BuiltinPackResourcesEntry> BUILTIN_PACK_RESOURCES = new HashSet<>();
 
+	private static final boolean DEBUG_RELOADERS_IDENTITY_STRICT = Boolean.getBoolean("fabric.resource_loader.debug.reloaders_identity.strict");
 	private static final boolean DEBUG_RELOADERS_IDENTITY = TriState.fromSystemProperty("fabric.resource_loader.debug.reloaders_identity")
-			.orElse(FabricLoader.getInstance().isDevelopmentEnvironment());
+			.orElse(DEBUG_RELOADERS_IDENTITY_STRICT || FabricLoader.getInstance().isDevelopmentEnvironment());
 	public static final boolean DEBUG_PROFILE_RESOURCE_RELOADERS = Boolean.getBoolean("fabric.resource_loader.debug.profile_resource_reloaders");
 	private static final boolean DEBUG_RELOADERS_ORDER = Boolean.getBoolean("fabric.resource_loader.debug.reloaders_order");
 
@@ -130,11 +131,12 @@ public sealed class ResourceLoaderImpl implements ResourceLoader permits DataRes
 			return identifiable.fabric$getId();
 		} else {
 			if (DEBUG_RELOADERS_IDENTITY) {
-				LOGGER.warn(
-						"The resource listener at {} does not use identifiable registration "
-								+ "making ordering support more difficult for other modders.",
-						reloader.getClass().getName()
-				);
+				String message = "The resource listener at %s does not use identifiable registration making ordering support more difficult for other modders.".formatted(reloader.getClass().getName());
+				LOGGER.warn(message);
+
+				if (DEBUG_RELOADERS_IDENTITY_STRICT) {
+					throw new IllegalStateException(message);
+				}
 			}
 
 			return Identifier.fromNamespaceAndPath("unknown",


### PR DESCRIPTION
Also crash on this error in the FAPI dev env so this doesnt happen agian.