### PR TITLE
Handle out of order command packets (fix #5423)

### DIFF
--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
@@ -68,6 +68,10 @@ public final class ClientCommandInternals {
 		return activeDispatcher;
 	}
 
+	public static boolean isEmpty() {
+		return activeDispatcher == null || activeDispatcher.getRoot().getChildren().isEmpty();
+	}
+
 	/**
 	 * Executes a client-sided command. Callers should ensure that this is only called
 	 * on slash-prefixed messages and the slash needs to be removed before calling.
@@ -227,6 +231,10 @@ public final class ClientCommandInternals {
 	}
 
 	public static void addCommands(CommandDispatcher<FabricClientCommandSource> target, FabricClientCommandSource source) {
+		if (activeDispatcher == null) {
+			LOGGER.warn("Tried to add client commands, but the dispatcher wasn't set up!");
+		}
+
 		Map<CommandNode<FabricClientCommandSource>, CommandNode<FabricClientCommandSource>> nodes = new HashMap<>();
 		nodes.put(activeDispatcher.getRoot(), target.getRoot());
 		copyChildren(activeDispatcher.getRoot(), target.getRoot(), source, nodes);

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/impl/command/client/ClientCommandInternals.java
@@ -233,6 +233,7 @@ public final class ClientCommandInternals {
 	public static void addCommands(CommandDispatcher<FabricClientCommandSource> target, FabricClientCommandSource source) {
 		if (activeDispatcher == null) {
 			LOGGER.warn("Tried to add client commands, but the dispatcher wasn't set up!");
+			return;
 		}
 
 		Map<CommandNode<FabricClientCommandSource>, CommandNode<FabricClientCommandSource>> nodes = new HashMap<>();

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
@@ -65,11 +65,11 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 	@Shadow
 	private RegistryAccess.Frozen registryAccess;
 
-	@Unique
-	private @Nullable ClientboundCommandsPacket lastReceivedCommandsPacket = null;
+	@Shadow
+	public abstract void handleCommands(ClientboundCommandsPacket packet);
 
 	@Unique
-	private boolean receivedCommands = false;
+	private volatile @Nullable ClientboundCommandsPacket lastReceivedCommandsPacket = null;
 
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void init(Minecraft minecraft, Connection connection, CommonListenerCookie cookie, CallbackInfo ci) {
@@ -86,7 +86,12 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 
 		// Check if commands were already received to handle custom server implementations
 		// that don't follow vanilla packet order
-		if (this.receivedCommands) {
+		if (this.lastReceivedCommandsPacket != null) {
+			// Rebuilds commands if command packet was already received.
+			this.handleCommands(this.lastReceivedCommandsPacket);
+		} else {
+			// Add commands even if packet wasn't received, in case of custom server impl that doesn't send commands at all.
+			// Unlikely, but can happen technically.
 			this.addClientCommands();
 		}
 	}
@@ -94,7 +99,6 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Inject(method = "handleCommands", at = @At("RETURN"))
 	private void onOnCommandTree(ClientboundCommandsPacket packet, CallbackInfo info) {
-		this.receivedCommands = true;
 		this.addClientCommands();
 	}
 

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
@@ -69,7 +69,7 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 	public abstract void handleCommands(ClientboundCommandsPacket packet);
 
 	@Unique
-	private volatile @Nullable ClientboundCommandsPacket lastReceivedCommandsPacket = null;
+	private @Nullable ClientboundCommandsPacket lastReceivedCommandsPacket = null;
 
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void init(Minecraft minecraft, Connection connection, CommonListenerCookie cookie, CallbackInfo ci) {

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
@@ -68,22 +68,43 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 	@Unique
 	private @Nullable ClientboundCommandsPacket lastReceivedCommandsPacket = null;
 
+	@Unique
+	private boolean receivedCommands = false;
+
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void init(Minecraft minecraft, Connection connection, CommonListenerCookie cookie, CallbackInfo ci) {
 		((ClientSuggestionProviderExtensions) this.suggestionsProvider).fabric_markAttended();
 	}
 
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Inject(method = "handleLogin", at = @At("RETURN"))
 	private void onGameJoin(ClientboundLoginPacket packet, CallbackInfo info) {
 		final CommandDispatcher<FabricClientCommandSource> dispatcher = new CommandDispatcher<>();
 		ClientCommandInternals.setActiveDispatcher(dispatcher);
 		ClientCommandRegistrationCallback.EVENT.invoker().register(dispatcher, CommandBuildContext.simple(this.registryAccess, this.enabledFeatures));
 		ClientCommandInternals.finalizeInit();
+
+		// Check if commands were already received to handle custom server implementations
+		// that don't follow vanilla packet order
+		if (this.receivedCommands) {
+			this.addClientCommands();
+		}
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Inject(method = "handleCommands", at = @At("RETURN"))
 	private void onOnCommandTree(ClientboundCommandsPacket packet, CallbackInfo info) {
+		this.receivedCommands = true;
+		this.addClientCommands();
+	}
+
+	@Unique
+	private void addClientCommands() {
+		// Client commands might have not been set up yet (or are just empty)!
+		if (ClientCommandInternals.isEmpty()) {
+			return;
+		}
+
 		// Add the commands to the vanilla dispatcher for completion.
 		// It's done here because both the server and the client commands have
 		// to be in the same dispatcher and completion results.

--- a/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
+++ b/fabric-command-api-v2/src/client/java/net/fabricmc/fabric/mixin/command/client/ClientPacketListenerMixin.java
@@ -76,7 +76,6 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 		((ClientSuggestionProviderExtensions) this.suggestionsProvider).fabric_markAttended();
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Inject(method = "handleLogin", at = @At("RETURN"))
 	private void onGameJoin(ClientboundLoginPacket packet, CallbackInfo info) {
 		final CommandDispatcher<FabricClientCommandSource> dispatcher = new CommandDispatcher<>();
@@ -96,13 +95,13 @@ abstract class ClientPacketListenerMixin implements ClientCommandInternals.LastR
 		}
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Inject(method = "handleCommands", at = @At("RETURN"))
 	private void onOnCommandTree(ClientboundCommandsPacket packet, CallbackInfo info) {
 		this.addClientCommands();
 	}
 
 	@Unique
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	private void addClientCommands() {
 		// Client commands might have not been set up yet (or are just empty)!
 		if (ClientCommandInternals.isEmpty()) {


### PR DESCRIPTION
Fixes issue where client crashes when custom server sends the command packet before login one (vanilla handles this case without any known issues). This could be backported to older versions, as this shouldn't change behaviour in cases where it already worked.