### PR TITLE
RecipeProvider: Output stonecutting recipes in result item’s namespace

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -290,20 +290,6 @@
             <message key="matchxpath.match" value="ordinal is not allowed in @Local annotations on method parameters"/>
         </module>
 
-        <!-- Prevent specifying name and argsOnly in @Local annotations on method parameters -->
-        <module name="MatchXpath">
-            <property name="query" value="
-                //PARAMETER_DEF/MODIFIERS/ANNOTATION[
-                    ./IDENT[@text='Local']
-                    and
-                    ./ANNOTATION_MEMBER_VALUE_PAIR/IDENT[@text='name']
-                    and
-                    ./ANNOTATION_MEMBER_VALUE_PAIR/IDENT[@text='argsOnly']
-                ]
-            "/>
-            <message key="matchxpath.match" value="name and argsOnly cannot both be specified in @Local, perfer argsOnly"/>
-        </module>
-
         <module name="MatchXpath">
             <property name="query" value="//LITERAL_ASSERT"/>
             <message key="matchxpath.match" value="Avoid using 'assert'."/>

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/RecipeProviderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/RecipeProviderMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.datagen.recipe;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.data.recipes.RecipeProvider;
+import net.minecraft.data.recipes.packs.VanillaRecipeProvider;
+import net.minecraft.world.level.ItemLike;
+
+@Mixin(RecipeProvider.class)
+abstract class RecipeProviderMixin {
+	// The default `RecipeProvider` outputs all stonecutting recipes
+	// in the `minecraft` namespace. Override this method to place
+	// them in the output item’s namespace instead.
+	@ModifyArg(method = "stonecutterResultFromBase(Lnet/minecraft/data/recipes/RecipeCategory;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/data/recipes/SingleItemRecipeBuilder;save(Lnet/minecraft/data/recipes/RecipeOutput;Ljava/lang/String;)V"), index = 1)
+	private String adjustId(String path, @Local(name = "result", argsOnly = true) ItemLike result) {
+		if ((Object) this instanceof VanillaRecipeProvider) {
+			return path;
+		}
+
+		return BuiltInRegistries.ITEM.getKey(result.asItem()).getNamespace() + ":" + path;
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -20,7 +20,8 @@
     "recipe.RecipeOutputMixin",
     "recipe.SpecialRecipeBuilderMixin",
     "recipe.SmithingTransformRecipeBuilderMixin",
-    "recipe.SmithingTrimRecipeBuilderMixin"
+    "recipe.SmithingTrimRecipeBuilderMixin",
+    "recipe.RecipeProviderMixin"
   ],
   "server": [
     "server.MainMixin"

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/building_blocks/simple_block_from_glass_stonecutting.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/recipes/building_blocks/simple_block_from_glass_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_glass": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:glass"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "fabric-data-gen-api-v1-testmod:simple_block_from_glass_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_glass"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "fabric-data-gen-api-v1-testmod:simple_block_from_glass_stonecutting"
+    ]
+  }
+}

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/recipe/simple_block_from_glass_stonecutting.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/recipe/simple_block_from_glass_stonecutting.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": "minecraft:glass",
+  "result": {
+    "id": "fabric-data-gen-api-v1-testmod:simple_block"
+  }
+}

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -245,6 +245,9 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 									Ingredient.of(Items.IRON_INGOT, Items.GOLD_INGOT, Items.DIAMOND)))
 							.unlockedBy("has_payment", has(ItemTags.BEACON_PAYMENT_ITEMS))
 							.save(this.output);
+
+					// Test stonecutting
+					stonecutterResultFromBase(RecipeCategory.BUILDING_BLOCKS, SIMPLE_BLOCK, Items.GLASS);
 				}
 			};
 		}


### PR DESCRIPTION
Minecraft’s `RecipeProvider.stonecutterResultFromBase` method always outputs recipes in the `minecraft` namespace; this PR makes it use the namespace of the result item unless the recipe provider is an instance of `VanillaRecipeProvider`.