### PR TITLE
Add `#c:incorrect_for_any_tool` tag

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
@@ -175,19 +175,19 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.add(Blocks.REDSTONE_ORE);
 
 		valueLookupBuilder(BlockTags.INCORRECT_FOR_COPPER_TOOL)
-				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+				.addOptionalTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
 		valueLookupBuilder(BlockTags.INCORRECT_FOR_DIAMOND_TOOL)
-				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+				.addOptionalTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
 		valueLookupBuilder(BlockTags.INCORRECT_FOR_GOLD_TOOL)
-				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+				.addOptionalTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
 		valueLookupBuilder(BlockTags.INCORRECT_FOR_IRON_TOOL)
-				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+				.addOptionalTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
 		valueLookupBuilder(BlockTags.INCORRECT_FOR_NETHERITE_TOOL)
-				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+				.addOptionalTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
 		valueLookupBuilder(BlockTags.INCORRECT_FOR_STONE_TOOL)
-				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+				.addOptionalTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
 		valueLookupBuilder(BlockTags.INCORRECT_FOR_WOODEN_TOOL)
-				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+				.addOptionalTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
 
 		valueLookupBuilder(ConventionalBlockTags.WOODEN_CHESTS)
 				.add(Blocks.CHEST)

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
@@ -174,6 +174,21 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.add(Blocks.LAPIS_ORE)
 				.add(Blocks.REDSTONE_ORE);
 
+		valueLookupBuilder(BlockTags.INCORRECT_FOR_COPPER_TOOL)
+				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+		valueLookupBuilder(BlockTags.INCORRECT_FOR_DIAMOND_TOOL)
+				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+		valueLookupBuilder(BlockTags.INCORRECT_FOR_GOLD_TOOL)
+				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+		valueLookupBuilder(BlockTags.INCORRECT_FOR_IRON_TOOL)
+				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+		valueLookupBuilder(BlockTags.INCORRECT_FOR_NETHERITE_TOOL)
+				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+		valueLookupBuilder(BlockTags.INCORRECT_FOR_STONE_TOOL)
+				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+		valueLookupBuilder(BlockTags.INCORRECT_FOR_WOODEN_TOOL)
+				.addTag(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL);
+
 		valueLookupBuilder(ConventionalBlockTags.WOODEN_CHESTS)
 				.add(Blocks.CHEST)
 				.add(Blocks.TRAPPED_CHEST);

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
@@ -72,6 +72,7 @@ public class EnglishTagLangGenerator extends FabricLanguageProvider {
 		translationBuilder.add(ConventionalBlockTags.ORES_IN_GROUND_DEEPSLATE, "Deepslate Ores In Ground");
 		translationBuilder.add(ConventionalBlockTags.ORES_IN_GROUND_NETHERRACK, "Netherrack Ores In Ground");
 		translationBuilder.add(ConventionalBlockTags.ORES_IN_GROUND_STONE, "Stone Ores In Ground");
+		translationBuilder.add(ConventionalBlockTags.INCORRECT_FOR_ANY_TOOL, "Incorrect for Any Tool");
 		translationBuilder.add(ConventionalBlockTags.BARRELS, "Barrels");
 		translationBuilder.add(ConventionalBlockTags.WOODEN_BARRELS, "Wooden Barrels");
 		translationBuilder.add(ConventionalBlockTags.BOOKSHELVES, "Bookshelves");

--- a/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
+++ b/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
@@ -55,6 +55,7 @@
   "tag.block.c.glazed_terracottas": "Glazed Terracottas",
   "tag.block.c.gravels": "Gravels",
   "tag.block.c.hidden_from_recipe_viewers": "Hidden From Recipe Viewers",
+  "tag.block.c.incorrect_for_any_tool": "Incorrect for Any Tool",
   "tag.block.c.natural_logs": "Natural Logs",
   "tag.block.c.natural_logs.nether": "Nether Natural Logs",
   "tag.block.c.natural_logs.overworld": "Overworld Natural Logs",

--- a/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_copper_tool.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_copper_tool.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#c:incorrect_for_any_tool",
+      "required": false
+    }
+  ]
+}

--- a/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_diamond_tool.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_diamond_tool.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#c:incorrect_for_any_tool",
+      "required": false
+    }
+  ]
+}

--- a/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_gold_tool.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_gold_tool.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#c:incorrect_for_any_tool",
+      "required": false
+    }
+  ]
+}

--- a/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_iron_tool.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_iron_tool.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#c:incorrect_for_any_tool",
+      "required": false
+    }
+  ]
+}

--- a/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_netherite_tool.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_netherite_tool.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#c:incorrect_for_any_tool",
+      "required": false
+    }
+  ]
+}

--- a/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_stone_tool.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_stone_tool.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#c:incorrect_for_any_tool",
+      "required": false
+    }
+  ]
+}

--- a/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_wooden_tool.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/minecraft/tags/block/incorrect_for_wooden_tool.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#c:incorrect_for_any_tool",
+      "required": false
+    }
+  ]
+}

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalBlockTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalBlockTags.java
@@ -92,6 +92,22 @@ public final class ConventionalBlockTags {
 	 */
 	public static final TagKey<Block> REDSTONE_ORES = register("ores/redstone");
 
+	/**
+	 * Blocks that can harvested only with a few specific tool materials.
+	 *
+	 * <p>This is included in all `minecraft:incorrect_for_*_tool` tags and
+	 * should be included in similar modded tags, directly or transitively
+	 * through a vanilla tag.
+	 *
+	 * <p>Use tag entry removals to remove the desired blocks from the
+	 * 'incorrect' tags for the tool materials that <em>should</em> be
+	 * able to mine them.
+	 *
+	 * <p>This tag is not meant for blocks that are not meant to be
+	 * harvested at all; use an empty loot table for such blocks.
+	 */
+	public static final TagKey<Block> INCORRECT_FOR_ANY_TOOL = register("incorrect_for_any_tool");
+
 	public static final TagKey<Block> BARRELS = register("barrels");
 	public static final TagKey<Block> WOODEN_BARRELS = register("barrels/wooden");
 	public static final TagKey<Block> BOOKSHELVES = register("bookshelves");


### PR DESCRIPTION
[Discussion on Discord](https://discord.com/channels/507304429255393322/566276937035546624/1515120400609186002)

Adds a `#c:incorrect_for_any_tool` block tag that is included in all `#minecraft:incorrect_for_*_tool` tags. This is meant for blocks that are harvestable by only a few particular tiers[^1]: these blocks could be added to `#c:incorrect_for_any_tool` then removed from the appropriate `incorrect_for_*_tool` tag using tag entry removals.

[^1]: For instance, I’m adding a block that I want to be harvestable only by golden pickaxes.

## Questions

- This is pretty niche; do we want this in Fabric API?
  - Could potentially be useful for tool materials *above* diamond/netherite
- What if someone forgets to put `#c:incorrect_for_any_tool` in their tool tag?
  - Doesn’t seem to be a problem in the wild; [a cursory search](https://github.com/search?q=%252Fincorrect_for_%5Cw%252B_tool%252F+language%253Ajson&type=code) indicates that people are inheriting from one of the vanilla tags
- This is the first time that Conventional Tags is adding to a vanilla tag; could be problematic since adding to `#c:incorrect_for_any_tool` changes user-visible behavior even in the absence of other mods