### PR TITLE
Feat: add methods to modify components in FabricItem.Properties

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 import net.minecraft.core.component.DataComponentType;
 
@@ -31,6 +32,16 @@ import net.minecraft.core.component.DataComponentType;
  */
 @ApiStatus.NonExtendable
 public interface FabricComponentMapBuilder {
+	/**
+	 * Gets the current value for the component type in the builder, or {@code null} if it is not present.
+	 * @param type The component type
+	 * @param <T> The type of the component data
+	 * @return Returns the current value in the map builder, or {@code null} if not present
+	 */
+	default <T> @Nullable T get(DataComponentType<T> type) {
+		throw new AssertionError("Implemented in Mixin");
+	}
+
 	/**
 	 * Gets the current value for the component type in the builder, or creates and adds a new value if it is not present.
 	 *

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -19,9 +19,13 @@ package net.fabricmc.fabric.api.item.v1;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang3.function.TriFunction;
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponentInitializers;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
@@ -168,6 +172,30 @@ public interface FabricItem {
 	 * This interface is automatically implemented on all item properties via Mixin and interface injection.
 	 */
 	interface Properties {
+		/**
+		 * Modifies the value of a component. The original value may be null if no initializer for this component type was registered, or the initializer for this component type was registered after the modifier. Returning null will remove the value for this component type.
+		 * @param type the {@link DataComponentType} of the component to modify
+		 * @param modifier the modifier to run on the component
+		 * @param <T> the type of the component
+		 * @return this builder
+		 */
+		default <T> Item.Properties modifyComponent(DataComponentType<T> type, TriFunction<@Nullable T, HolderLookup.Provider, ResourceKey<Item>, @Nullable T> modifier) {
+			return this.modifyComponents((builder, registries, id) -> {
+				builder.set(type, modifier.apply(builder.get(type), registries, id));
+			});
+		}
+
+		/**
+		 * Modifies the value of all components initialized by initializers up to this point.
+		 * @param modifier the modifier to apply
+		 * @return this builder
+		 */
+		default Item.Properties modifyComponents(DataComponentInitializers.Initializer<Item> modifier) {
+			Item.Properties self = (Item.Properties) this;
+			self.componentInitializer.andThen(modifier);
+			return self;
+		}
+
 		/**
 		 * Sets the equipment slot provider of the item.
 		 *

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricItem.java
@@ -192,7 +192,7 @@ public interface FabricItem {
 		 */
 		default Item.Properties modifyComponents(DataComponentInitializers.Initializer<Item> modifier) {
 			Item.Properties self = (Item.Properties) this;
-			self.componentInitializer.andThen(modifier);
+			self.componentInitializer = self.componentInitializer.andThen(modifier);
 			return self;
 		}
 

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/DataComponentMapBuilderMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/DataComponentMapBuilderMixin.java
@@ -42,6 +42,12 @@ abstract class DataComponentMapBuilderMixin implements FabricComponentMapBuilder
 	@Shadow
 	public abstract <T> DataComponentMap.Builder set(DataComponentType<T> dataComponentType, @Nullable T object);
 
+	@SuppressWarnings("unchecked")
+	@Override
+	public @Nullable <T> T get(DataComponentType<T> type) {
+		return (T) this.map.get(type);
+	}
+
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getOrCreate(DataComponentType<T> type, Supplier<T> fallback) {

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.classtweaker
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.classtweaker
@@ -1,4 +1,5 @@
 classTweaker	v1	official
+accessible field net/minecraft/world/item/Item$Properties componentInitializer Lnet/minecraft/core/component/DataComponentInitializers$Initializer;
 accessible class net/minecraft/resources/RegistryLoadTask$PendingRegistration
 accessible class net/minecraft/core/component/DataComponentInitializers$BakedEntry
 accessible class net/minecraft/core/component/DataComponentInitializers$PendingComponentBuilders

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ModifyComponentsInPropertiesTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ModifyComponentsInPropertiesTest.java
@@ -43,7 +43,7 @@ import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 public class ModifyComponentsInPropertiesTest implements ModInitializer {
 	@Override
 	public void onInitialize() {
-		var item = Registry.register(
+		Item item = Registry.register(
 				BuiltInRegistries.ITEM,
 				Identifier.fromNamespaceAndPath("fabric-item-api-v1-testmod", "op_sword"),
 				new Item(new Item.Properties().setId(ResourceKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath("fabric-item-api-v1-testmod", "op_sword"))).sword(ToolMaterial.NETHERITE, 3.0F, -2.4F).fireResistant().modifyComponent(DataComponents.TOOL, (original, _, _) -> {

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ModifyComponentsInPropertiesTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ModifyComponentsInPropertiesTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.item;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.Unit;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ToolMaterial;
+import net.minecraft.world.item.component.Tool;
+import net.minecraft.world.level.block.Blocks;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+
+public class ModifyComponentsInPropertiesTest implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		var item = Registry.register(
+				BuiltInRegistries.ITEM,
+				Identifier.fromNamespaceAndPath("fabric-item-api-v1-testmod", "op_sword"),
+				new Item(new Item.Properties().setId(ResourceKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath("fabric-item-api-v1-testmod", "op_sword"))).sword(ToolMaterial.NETHERITE, 3.0F, -2.4F).fireResistant().modifyComponent(DataComponents.TOOL, (original, _, _) -> {
+					// derived from ToolMaterial#applySwordProperties
+					var newRules = new ArrayList<>(Objects.requireNonNull(original, "sword method did not add a tool component?").rules());
+					newRules.addFirst(new Tool.Rule(HolderSet.direct(Blocks.DIRT.builtInRegistryHolder()), Optional.of(44f), Optional.of(false)));
+					return new Tool(List.copyOf(newRules), original.defaultMiningSpeed(), original.damagePerBlock(), original.canDestroyBlocksInCreative());
+				}))
+		);
+
+		HashMap<UUID, Unit> giftedMap = new HashMap<>();
+		ServerTickEvents.START_SERVER_TICK.register(server -> PlayerLookup.all(server).forEach(player -> {
+			if (!giftedMap.containsKey(player.getUUID())) {
+				player.drop(item.getDefaultInstance(), true);
+				giftedMap.put(player.getUUID(), Unit.INSTANCE);
+			}
+		}));
+	}
+}

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ModifyComponentsInPropertiesTestSetup.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ModifyComponentsInPropertiesTestSetup.java
@@ -17,11 +17,9 @@
 package net.fabricmc.fabric.test.item;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
@@ -30,17 +28,15 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.util.Unit;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ToolMaterial;
 import net.minecraft.world.item.component.Tool;
 import net.minecraft.world.level.block.Blocks;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
-import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 
-public class ModifyComponentsInPropertiesTest implements ModInitializer {
+public class ModifyComponentsInPropertiesTestSetup implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		Item item = Registry.register(
@@ -54,12 +50,13 @@ public class ModifyComponentsInPropertiesTest implements ModInitializer {
 				}))
 		);
 
-		HashMap<UUID, Unit> giftedMap = new HashMap<>();
-		ServerTickEvents.START_SERVER_TICK.register(server -> PlayerLookup.all(server).forEach(player -> {
-			if (!giftedMap.containsKey(player.getUUID())) {
-				player.drop(item.getDefaultInstance(), true);
-				giftedMap.put(player.getUUID(), Unit.INSTANCE);
+		ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+			if (item.getDefaultInstance().getDestroySpeed(Blocks.ACACIA_BUTTON.defaultBlockState()) == 44f) {
+				throw new AssertionError("ModifyComponentsInPropertiesTestSetup failed");
 			}
-		}));
+			if (item.getDefaultInstance().getDestroySpeed(Blocks.DIRT.defaultBlockState()) != 44f) {
+				throw new AssertionError("ModifyComponentsInPropertiesTestSetup failed");
+			}
+		});
 	}
 }

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ModifyComponentsInPropertiesTestSetup.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ModifyComponentsInPropertiesTestSetup.java
@@ -54,6 +54,7 @@ public class ModifyComponentsInPropertiesTestSetup implements ModInitializer {
 			if (item.getDefaultInstance().getDestroySpeed(Blocks.ACACIA_BUTTON.defaultBlockState()) == 44f) {
 				throw new AssertionError("ModifyComponentsInPropertiesTestSetup failed");
 			}
+
 			if (item.getDefaultInstance().getDestroySpeed(Blocks.DIRT.defaultBlockState()) != 44f) {
 				throw new AssertionError("ModifyComponentsInPropertiesTestSetup failed");
 			}

--- a/fabric-item-api-v1/src/testmod/resources/assets/fabric-item-api-v1-testmod/items/op_sword.json
+++ b/fabric-item-api-v1/src/testmod/resources/assets/fabric-item-api-v1-testmod/items/op_sword.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "minecraft:item/netherite_shovel"
+  }
+}

--- a/fabric-item-api-v1/src/testmod/resources/assets/fabric-item-api-v1-testmod/models/item/op_sword.json
+++ b/fabric-item-api-v1/src/testmod/resources/assets/fabric-item-api-v1-testmod/models/item/op_sword.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:item/netherite_shovel"
+}

--- a/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
@@ -16,7 +16,8 @@
       "net.fabricmc.fabric.test.item.ItemUpdateAnimationTest",
       "net.fabricmc.fabric.test.item.CustomEnchantmentEffectsTest",
       "net.fabricmc.fabric.test.item.ComponentTooltipProviderTest",
-      "net.fabricmc.fabric.test.item.CreatorNamespaceTest"
+      "net.fabricmc.fabric.test.item.CreatorNamespaceTest",
+      "net.fabricmc.fabric.test.item.ModifyComponentsInPropertiesTest"
     ],
     "client": [
       "net.fabricmc.fabric.test.item.client.TooltipTests"

--- a/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
@@ -17,7 +17,7 @@
       "net.fabricmc.fabric.test.item.CustomEnchantmentEffectsTest",
       "net.fabricmc.fabric.test.item.ComponentTooltipProviderTest",
       "net.fabricmc.fabric.test.item.CreatorNamespaceTest",
-      "net.fabricmc.fabric.test.item.ModifyComponentsInPropertiesTest"
+      "net.fabricmc.fabric.test.item.ModifyComponentsInPropertiesTestSetup"
     ],
     "client": [
       "net.fabricmc.fabric.test.item.client.TooltipTests"


### PR DESCRIPTION
Add methods to modify components added by other initializers in Item.Properties. This can be useful to allow customizing the results of the application of an armor material, or tool material, or for many other reasons. This is currently possible with DefaultItemComponentEvents.