### PR TITLE
Add missing 26.2 content to C tags

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BiomeTagsGenerator.java
@@ -128,9 +128,10 @@ public final class BiomeTagsGenerator extends FabricTagsProvider<Biome> {
 		builder(ConventionalBiomeTags.IS_BADLANDS)
 				.addOptionalTag(BiomeTags.IS_BADLANDS);
 		builder(ConventionalBiomeTags.IS_CAVE)
-				.add(Biomes.DEEP_DARK)
+				.add(Biomes.LUSH_CAVES)
 				.add(Biomes.DRIPSTONE_CAVES)
-				.add(Biomes.LUSH_CAVES);
+				.add(Biomes.SULFUR_CAVES)
+				.add(Biomes.DEEP_DARK);
 		builder(ConventionalBiomeTags.IS_VOID)
 				.add(Biomes.THE_VOID);
 		builder(ConventionalBiomeTags.IS_DEEP_OCEAN)
@@ -238,7 +239,8 @@ public final class BiomeTagsGenerator extends FabricTagsProvider<Biome> {
 				.add(Biomes.SPARSE_JUNGLE)
 				.add(Biomes.BEACH)
 				.add(Biomes.LUSH_CAVES)
-				.add(Biomes.DRIPSTONE_CAVES);
+				.add(Biomes.DRIPSTONE_CAVES)
+				.add(Biomes.SULFUR_CAVES);
 		builder(ConventionalBiomeTags.IS_WET_NETHER);
 		builder(ConventionalBiomeTags.IS_WET_END);
 		builder(ConventionalBiomeTags.IS_WET)

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/EnglishTagLangGenerator.java
@@ -283,6 +283,7 @@ public class EnglishTagLangGenerator extends FabricLanguageProvider {
 		translationBuilder.add(ConventionalItemTags.BUCKETS, "Buckets");
 		translationBuilder.add(ConventionalItemTags.WATER_BUCKETS, "Water Buckets");
 		translationBuilder.add(ConventionalItemTags.ENTITY_WATER_BUCKETS, "Entity Water Buckets");
+		translationBuilder.add(ConventionalItemTags.ENTITY_DRY_BUCKETS, "Entity Dry Buckets");
 		translationBuilder.add(ConventionalItemTags.LAVA_BUCKETS, "Lava Buckets");
 		translationBuilder.add(ConventionalItemTags.MILK_BUCKETS, "Milk Buckets");
 		translationBuilder.add(ConventionalItemTags.POWDER_SNOW_BUCKETS, "Powder Snow Buckets");

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagsGenerator.java
@@ -378,6 +378,8 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 				.add(ItemIds.BUCKET);
 		builder(ConventionalItemTags.LAVA_BUCKETS)
 				.add(ItemIds.LAVA_BUCKET);
+		builder(ConventionalItemTags.ENTITY_DRY_BUCKETS)
+				.add(ItemIds.SULFUR_CUBE_BUCKET);
 		builder(ConventionalItemTags.ENTITY_WATER_BUCKETS)
 				.add(ItemIds.AXOLOTL_BUCKET)
 				.add(ItemIds.COD_BUCKET)
@@ -397,7 +399,8 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 				.addOptionalTag(ConventionalItemTags.LAVA_BUCKETS)
 				.addOptionalTag(ConventionalItemTags.MILK_BUCKETS)
 				.addOptionalTag(ConventionalItemTags.POWDER_SNOW_BUCKETS)
-				.addOptionalTag(ConventionalItemTags.ENTITY_WATER_BUCKETS);
+				.addOptionalTag(ConventionalItemTags.ENTITY_WATER_BUCKETS)
+				.addOptionalTag(ConventionalItemTags.ENTITY_DRY_BUCKETS);
 	}
 
 	private void generateOreAndRelatedTags() {

--- a/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
+++ b/fabric-convention-tags-v2/src/generated/resources/assets/fabric-convention-tags-v2/lang/en_us.json
@@ -170,6 +170,7 @@
   "tag.item.c.bricks.resin": "Resin Bricks",
   "tag.item.c.buckets": "Buckets",
   "tag.item.c.buckets.empty": "Empty Buckets",
+  "tag.item.c.buckets.entity_dry": "Entity Dry Buckets",
   "tag.item.c.buckets.entity_water": "Entity Water Buckets",
   "tag.item.c.buckets.lava": "Lava Buckets",
   "tag.item.c.buckets.milk": "Milk Buckets",

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/buckets.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/buckets.json
@@ -23,6 +23,10 @@
     {
       "id": "#c:buckets/entity_water",
       "required": false
+    },
+    {
+      "id": "#c:buckets/entity_dry",
+      "required": false
     }
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/buckets/entity_dry.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/buckets/entity_dry.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:sulfur_cube_bucket"
+  ]
+}

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/worldgen/biome/is_cave.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/worldgen/biome/is_cave.json
@@ -1,7 +1,8 @@
 {
   "values": [
-    "minecraft:deep_dark",
+    "minecraft:lush_caves",
     "minecraft:dripstone_caves",
-    "minecraft:lush_caves"
+    "minecraft:sulfur_caves",
+    "minecraft:deep_dark"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/worldgen/biome/is_wet/overworld.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/worldgen/biome/is_wet/overworld.json
@@ -7,6 +7,7 @@
     "minecraft:sparse_jungle",
     "minecraft:beach",
     "minecraft:lush_caves",
-    "minecraft:dripstone_caves"
+    "minecraft:dripstone_caves",
+    "minecraft:sulfur_caves"
   ]
 }

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalItemTags.java
@@ -341,6 +341,7 @@ public final class ConventionalItemTags {
 	public static final TagKey<Item> MILK_BUCKETS = register("buckets/milk");
 	public static final TagKey<Item> POWDER_SNOW_BUCKETS = register("buckets/powder_snow");
 	public static final TagKey<Item> ENTITY_WATER_BUCKETS = register("buckets/entity_water");
+	public static final TagKey<Item> ENTITY_DRY_BUCKETS = register("buckets/entity_dry");
 
 	public static final TagKey<Item> BARRELS = register("barrels");
 	public static final TagKey<Item> WOODEN_BARRELS = register("barrels/wooden");


### PR DESCRIPTION
- Sulfur Cube Bucket in new `c:buckets\entity_dry`
- Added Sulfur Caves to `c:is_caves` and `c:is_wet\overworld`
- Ordered `c:is_caves` biome tag to a nicer ordering (matches neo's order)

Neo PR: https://github.com/neoforged/NeoForge/pull/3251