### PR TITLE
Update Checkstyle report action to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: gradle/actions/wrapper-validation@v5
       - run: ./gradlew check build outJar :buildSrc:check publishToMavenLocal --stacktrace
-      - uses: FabricMCBot/publish-checkstyle-report@4627c82002aa370b6cb2a3140f34c7a8c55a5297
+      - uses: FabricMCBot/publish-checkstyle-report@v3
         if: ${{ failure() }}
         with:
           reports: |


### PR DESCRIPTION
The main change in the action update is the mandatory Node update. This change should be backported to all maintained versions.