### PR TITLE
fix: screen testmod crash

### DIFF
--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/SoundButton.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/SoundButton.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.fabric.test.screen;
 
+import java.util.function.Supplier;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
@@ -26,13 +28,11 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.RandomSource;
 
-import java.util.function.Supplier;
-
 class SoundButton extends Button.Plain {
 	private static final RandomSource RANDOM = RandomSource.create();
 
 	SoundButton(int x, int y, int width, int height) {
-		super(x, y, width, height, Component.nullToEmpty("Sound Button"), ctx -> {
+		super(x, y, width, height, Component.nullToEmpty("Sound Button"), _ -> {
 			final SoundEvent event = BuiltInRegistries.SOUND_EVENT.getRandom(RANDOM).map(Holder::value).orElse(SoundEvents.GENERIC_EXPLODE.value());
 			Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(event, 1.0F, 1.0F));
 		}, Supplier::get);

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/SoundButton.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/SoundButton.java
@@ -21,17 +21,20 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.RandomSource;
+
+import java.util.function.Supplier;
 
 class SoundButton extends Button.Plain {
 	private static final RandomSource RANDOM = RandomSource.create();
 
 	SoundButton(int x, int y, int width, int height) {
-		super(x, y, width, height, net.minecraft.network.chat.Component.nullToEmpty("Sound Button"), ctx -> {
+		super(x, y, width, height, Component.nullToEmpty("Sound Button"), ctx -> {
 			final SoundEvent event = BuiltInRegistries.SOUND_EVENT.getRandom(RANDOM).map(Holder::value).orElse(SoundEvents.GENERIC_EXPLODE.value());
 			Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(event, 1.0F, 1.0F));
-		}, null);
+		}, Supplier::get);
 	}
 }


### PR DESCRIPTION
Narration text can't be null, can just use the default from the supplier instead.

```java
---- Minecraft Crash Report ----
// Shall we play a game?

Time: 2026-06-22 20:20:06
Description: Narrating screen

java.lang.NullPointerException: Cannot invoke "net.minecraft.client.gui.components.Button$CreateNarration.createNarrationMessage(java.util.function.Supplier)" because "this.createNarration" is null
	at knot//net.minecraft.client.gui.components.Button.createNarrationMessage(Button.java:114)
	at knot//net.minecraft.client.gui.components.AbstractWidget.defaultButtonNarrationText(AbstractWidget.java:250)
```