### PR TITLE
Make `FabricDataGenerator` extend `DataGenerator.Cached`

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/FabricDataGenerator.java
@@ -16,14 +16,13 @@
 
 package net.fabricmc.fabric.api.datagen.v1;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.jetbrains.annotations.ApiStatus;
 
+import net.minecraft.SharedConstants;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistrySetBuilder;
 import net.minecraft.data.DataGenerator;
@@ -33,13 +32,12 @@ import net.minecraft.data.registries.VanillaRegistries;
 import net.minecraft.resources.Identifier;
 
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagsProvider;
-import net.fabricmc.fabric.impl.datagen.FabricDataGenHelper;
 import net.fabricmc.loader.api.ModContainer;
 
 /**
  * An extension to vanilla's {@link DataGenerator} providing mod specific data, and helper functions.
  */
-public final class FabricDataGenerator extends DataGenerator.Uncached {
+public final class FabricDataGenerator extends DataGenerator.Cached {
 	private final ModContainer modContainer;
 	private final boolean strictValidation;
 	private final FabricPackOutput fabricOutput;
@@ -47,7 +45,7 @@ public final class FabricDataGenerator extends DataGenerator.Uncached {
 
 	@ApiStatus.Internal
 	public FabricDataGenerator(Path output, ModContainer mod, boolean strictValidation, CompletableFuture<HolderLookup.Provider> registriesFuture) {
-		super(output);
+		super(output, SharedConstants.getCurrentVersion(), true);
 		this.modContainer = Objects.requireNonNull(mod);
 		this.strictValidation = strictValidation;
 		this.fabricOutput = new FabricPackOutput(mod, output, strictValidation);
@@ -131,17 +129,6 @@ public final class FabricDataGenerator extends DataGenerator.Uncached {
 	@Deprecated
 	public DataGenerator.PackGenerator getBuiltinDatapack(boolean shouldRun, String packName) {
 		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void run() throws IOException {
-		Path output = vanillaPackOutput.getOutputFolder();
-
-		if (Files.exists(output)) {
-			FabricDataGenHelper.deleteDirectory(output);
-		}
-
-		super.run();
 	}
 
 	/**

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
@@ -16,13 +16,8 @@
 
 package net.fabricmc.fabric.impl.datagen;
 
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -257,23 +252,5 @@ public final class FabricDataGenHelper {
 		}
 
 		baseObject.add(ResourceConditions.CONDITIONS_KEY, ResourceCondition.LIST_CODEC.encodeStart(JsonOps.INSTANCE, Arrays.asList(conditions)).getOrThrow());
-	}
-
-	public static void deleteDirectory(Path dir) throws IOException {
-		Files.walkFileTree(dir, new SimpleFileVisitor<>() {
-			@Override
-			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-					throws IOException {
-				Files.delete(file);
-				return FileVisitResult.CONTINUE;
-			}
-
-			@Override
-			public FileVisitResult postVisitDirectory(Path dir, IOException exc)
-					throws IOException {
-				Files.delete(dir);
-				return FileVisitResult.CONTINUE;
-			}
-		});
 	}
 }


### PR DESCRIPTION
In Minecraft 26.1, `DataGenerator` was split into `DataGenerator.Cached` and `DataGenerator.Uncached`. `Cached` matches the pre-26.1 `DataGenerator` behaviour, while `Uncached` removes caching and doesn't remove stale files.

During the Fabric API update to account for the changes, `FabricDataGenerator` was made to extend `DataGenerator.Uncached` rather than `Cached` (1074095f3c400b04031b3a78e875bde0f8656110).
In the Fabric Discord server, the reasoning seems to have been that [caching was not used previously](https://discord.com/channels/507304429255393322/566276937035546624/1463204300594614446) and that [caching is hard/not really needed for mods](https://discord.com/channels/507304429255393322/789950127774105602/1463207290608816200). As far as I can tell, `FabricDataGenerator` was using caching before the update, so the reasoning might have been incorrect.

This PR makes `FabricDataGenerator` extend `Cached` rather than `Uncached` matching the pre-26.1 behaviour.
This is a breaking change, so not sure if this can be accepted for 26.1 & 26.2 or if it should target the next Minecraft release.

My use case would be for some of my mods like Rechiseled, where I generate thousands of files through datagen. Using caching would save time and resources by not having to delete and write unchanged files between datagen runs.