### PR TITLE
26.3 Convention Tags

### DIFF
--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import net.minecraft.core.HolderLookup;
+import net.minecraft.data.tags.BlockItemTagAppender;
 import net.minecraft.references.BlockIds;
 import net.minecraft.references.BlockItemId;
 import net.minecraft.references.BlockItemIds;
@@ -410,46 +411,18 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 	}
 
 	private void generateDyedTags() {
+		ColorCollection<BlockItemTagAppender<Block>> builders = ConventionalBlockTags.COLOR_DYED.map(this::builder);
+
 		for (ColorCollection<BlockItemId> colorCollection : List.of(
 				BlockItemIds.BANNER, BlockItemIds.BED, BlockItemIds.DYED_CANDLE, BlockItemIds.CARPET,
 				BlockItemIds.CONCRETE, BlockItemIds.CONCRETE_POWDER, BlockItemIds.GLAZED_TERRACOTTA,
 				BlockItemIds.DYED_SHULKER_BOX, BlockItemIds.STAINED_GLASS, BlockItemIds.STAINED_GLASS_PANE,
 				BlockItemIds.DYED_TERRACOTTA, BlockItemIds.WOOL, BlockItemIds.WOOL_SLAB, BlockItemIds.WOOL_STAIRS)) {
-			builder(ConventionalBlockTags.BLACK_DYED).add(colorCollection.black());
-			builder(ConventionalBlockTags.BLUE_DYED).add(colorCollection.blue());
-			builder(ConventionalBlockTags.BROWN_DYED).add(colorCollection.brown());
-			builder(ConventionalBlockTags.CYAN_DYED).add(colorCollection.cyan());
-			builder(ConventionalBlockTags.GRAY_DYED).add(colorCollection.gray());
-			builder(ConventionalBlockTags.GREEN_DYED).add(colorCollection.green());
-			builder(ConventionalBlockTags.LIGHT_BLUE_DYED).add(colorCollection.lightBlue());
-			builder(ConventionalBlockTags.LIGHT_GRAY_DYED).add(colorCollection.lightGray());
-			builder(ConventionalBlockTags.LIME_DYED).add(colorCollection.lime());
-			builder(ConventionalBlockTags.MAGENTA_DYED).add(colorCollection.magenta());
-			builder(ConventionalBlockTags.ORANGE_DYED).add(colorCollection.orange());
-			builder(ConventionalBlockTags.PINK_DYED).add(colorCollection.pink());
-			builder(ConventionalBlockTags.PURPLE_DYED).add(colorCollection.purple());
-			builder(ConventionalBlockTags.RED_DYED).add(colorCollection.red());
-			builder(ConventionalBlockTags.WHITE_DYED).add(colorCollection.white());
-			builder(ConventionalBlockTags.YELLOW_DYED).add(colorCollection.yellow());
+			ColorCollection.zipApply(builders, colorCollection, BlockItemTagAppender::add);
 		}
 
 		for (ColorCollection<ResourceKey<Block>> colorCollection : List.of(BlockIds.WALL_BANNER)) {
-			builder(ConventionalBlockTags.BLACK_DYED).add(colorCollection.black());
-			builder(ConventionalBlockTags.BLUE_DYED).add(colorCollection.blue());
-			builder(ConventionalBlockTags.BROWN_DYED).add(colorCollection.brown());
-			builder(ConventionalBlockTags.CYAN_DYED).add(colorCollection.cyan());
-			builder(ConventionalBlockTags.GRAY_DYED).add(colorCollection.gray());
-			builder(ConventionalBlockTags.GREEN_DYED).add(colorCollection.green());
-			builder(ConventionalBlockTags.LIGHT_BLUE_DYED).add(colorCollection.lightBlue());
-			builder(ConventionalBlockTags.LIGHT_GRAY_DYED).add(colorCollection.lightGray());
-			builder(ConventionalBlockTags.LIME_DYED).add(colorCollection.lime());
-			builder(ConventionalBlockTags.MAGENTA_DYED).add(colorCollection.magenta());
-			builder(ConventionalBlockTags.ORANGE_DYED).add(colorCollection.orange());
-			builder(ConventionalBlockTags.PINK_DYED).add(colorCollection.pink());
-			builder(ConventionalBlockTags.PURPLE_DYED).add(colorCollection.purple());
-			builder(ConventionalBlockTags.RED_DYED).add(colorCollection.red());
-			builder(ConventionalBlockTags.WHITE_DYED).add(colorCollection.white());
-			builder(ConventionalBlockTags.YELLOW_DYED).add(colorCollection.yellow());
+			ColorCollection.zipApply(builders, colorCollection, BlockItemTagAppender::add);
 		}
 
 		builder(ConventionalBlockTags.DYED)

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/BlockTagsGenerator.java
@@ -27,6 +27,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.BlockItemTags;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.ColorCollection;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricPackOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagsProvider;
@@ -129,7 +130,8 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.addOptionalTag(ConventionalBlockTags.LAPIS_ORES)
 				.addOptionalTag(ConventionalBlockTags.NETHERITE_SCRAP_ORES)
 				.addOptionalTag(ConventionalBlockTags.REDSTONE_ORES)
-				.addOptionalTag(ConventionalBlockTags.QUARTZ_ORES);
+				.addOptionalTag(ConventionalBlockTags.QUARTZ_ORES)
+				.addOptionalTag(BlockTags.ORES);
 
 		builder(ConventionalBlockTags.ORE_BEARING_GROUND_DEEPSLATE)
 				.add(BlockItemIds.DEEPSLATE);
@@ -408,101 +410,47 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 	}
 
 	private void generateDyedTags() {
-		builder(ConventionalBlockTags.BLACK_DYED)
-				.add(BlockItemIds.BANNER.black()).add(BlockItemIds.BED.black()).add(BlockItemIds.DYED_CANDLE.black()).add(BlockItemIds.CARPET.black())
-				.add(BlockItemIds.CONCRETE.black()).add(BlockItemIds.CONCRETE_POWDER.black()).add(BlockItemIds.GLAZED_TERRACOTTA.black())
-				.add(BlockItemIds.DYED_SHULKER_BOX.black()).add(BlockItemIds.STAINED_GLASS.black()).add(BlockItemIds.STAINED_GLASS_PANE.black())
-				.add(BlockItemIds.DYED_TERRACOTTA.black()).add(BlockIds.WALL_BANNER.black()).add(BlockItemIds.WOOL.black());
+		for (ColorCollection<BlockItemId> colorCollection : List.of(
+				BlockItemIds.BANNER, BlockItemIds.BED, BlockItemIds.DYED_CANDLE, BlockItemIds.CARPET,
+				BlockItemIds.CONCRETE, BlockItemIds.CONCRETE_POWDER, BlockItemIds.GLAZED_TERRACOTTA,
+				BlockItemIds.DYED_SHULKER_BOX, BlockItemIds.STAINED_GLASS, BlockItemIds.STAINED_GLASS_PANE,
+				BlockItemIds.DYED_TERRACOTTA, BlockItemIds.WOOL, BlockItemIds.WOOL_SLAB, BlockItemIds.WOOL_STAIRS)) {
+			builder(ConventionalBlockTags.BLACK_DYED).add(colorCollection.black());
+			builder(ConventionalBlockTags.BLUE_DYED).add(colorCollection.blue());
+			builder(ConventionalBlockTags.BROWN_DYED).add(colorCollection.brown());
+			builder(ConventionalBlockTags.CYAN_DYED).add(colorCollection.cyan());
+			builder(ConventionalBlockTags.GRAY_DYED).add(colorCollection.gray());
+			builder(ConventionalBlockTags.GREEN_DYED).add(colorCollection.green());
+			builder(ConventionalBlockTags.LIGHT_BLUE_DYED).add(colorCollection.lightBlue());
+			builder(ConventionalBlockTags.LIGHT_GRAY_DYED).add(colorCollection.lightGray());
+			builder(ConventionalBlockTags.LIME_DYED).add(colorCollection.lime());
+			builder(ConventionalBlockTags.MAGENTA_DYED).add(colorCollection.magenta());
+			builder(ConventionalBlockTags.ORANGE_DYED).add(colorCollection.orange());
+			builder(ConventionalBlockTags.PINK_DYED).add(colorCollection.pink());
+			builder(ConventionalBlockTags.PURPLE_DYED).add(colorCollection.purple());
+			builder(ConventionalBlockTags.RED_DYED).add(colorCollection.red());
+			builder(ConventionalBlockTags.WHITE_DYED).add(colorCollection.white());
+			builder(ConventionalBlockTags.YELLOW_DYED).add(colorCollection.yellow());
+		}
 
-		builder(ConventionalBlockTags.BLUE_DYED)
-				.add(BlockItemIds.BANNER.blue()).add(BlockItemIds.BED.blue()).add(BlockItemIds.DYED_CANDLE.blue()).add(BlockItemIds.CARPET.blue())
-				.add(BlockItemIds.CONCRETE.blue()).add(BlockItemIds.CONCRETE_POWDER.blue()).add(BlockItemIds.GLAZED_TERRACOTTA.blue())
-				.add(BlockItemIds.DYED_SHULKER_BOX.blue()).add(BlockItemIds.STAINED_GLASS.blue()).add(BlockItemIds.STAINED_GLASS_PANE.blue())
-				.add(BlockItemIds.DYED_TERRACOTTA.blue()).add(BlockIds.WALL_BANNER.blue()).add(BlockItemIds.WOOL.blue());
-
-		builder(ConventionalBlockTags.BROWN_DYED)
-				.add(BlockItemIds.BANNER.brown()).add(BlockItemIds.BED.brown()).add(BlockItemIds.DYED_CANDLE.brown()).add(BlockItemIds.CARPET.brown())
-				.add(BlockItemIds.CONCRETE.brown()).add(BlockItemIds.CONCRETE_POWDER.brown()).add(BlockItemIds.GLAZED_TERRACOTTA.brown())
-				.add(BlockItemIds.DYED_SHULKER_BOX.brown()).add(BlockItemIds.STAINED_GLASS.brown()).add(BlockItemIds.STAINED_GLASS_PANE.brown())
-				.add(BlockItemIds.DYED_TERRACOTTA.brown()).add(BlockIds.WALL_BANNER.brown()).add(BlockItemIds.WOOL.brown());
-
-		builder(ConventionalBlockTags.CYAN_DYED)
-				.add(BlockItemIds.BANNER.cyan()).add(BlockItemIds.BED.cyan()).add(BlockItemIds.DYED_CANDLE.cyan()).add(BlockItemIds.CARPET.cyan())
-				.add(BlockItemIds.CONCRETE.cyan()).add(BlockItemIds.CONCRETE_POWDER.cyan()).add(BlockItemIds.GLAZED_TERRACOTTA.cyan())
-				.add(BlockItemIds.DYED_SHULKER_BOX.cyan()).add(BlockItemIds.STAINED_GLASS.cyan()).add(BlockItemIds.STAINED_GLASS_PANE.cyan())
-				.add(BlockItemIds.DYED_TERRACOTTA.cyan()).add(BlockIds.WALL_BANNER.cyan()).add(BlockItemIds.WOOL.cyan());
-
-		builder(ConventionalBlockTags.GRAY_DYED)
-				.add(BlockItemIds.BANNER.gray()).add(BlockItemIds.BED.gray()).add(BlockItemIds.DYED_CANDLE.gray()).add(BlockItemIds.CARPET.gray())
-				.add(BlockItemIds.CONCRETE.gray()).add(BlockItemIds.CONCRETE_POWDER.gray()).add(BlockItemIds.GLAZED_TERRACOTTA.gray())
-				.add(BlockItemIds.DYED_SHULKER_BOX.gray()).add(BlockItemIds.STAINED_GLASS.gray()).add(BlockItemIds.STAINED_GLASS_PANE.gray())
-				.add(BlockItemIds.DYED_TERRACOTTA.gray()).add(BlockIds.WALL_BANNER.gray()).add(BlockItemIds.WOOL.gray());
-
-		builder(ConventionalBlockTags.GREEN_DYED)
-				.add(BlockItemIds.BANNER.green()).add(BlockItemIds.BED.green()).add(BlockItemIds.DYED_CANDLE.green()).add(BlockItemIds.CARPET.green())
-				.add(BlockItemIds.CONCRETE.green()).add(BlockItemIds.CONCRETE_POWDER.green()).add(BlockItemIds.GLAZED_TERRACOTTA.green())
-				.add(BlockItemIds.DYED_SHULKER_BOX.green()).add(BlockItemIds.STAINED_GLASS.green()).add(BlockItemIds.STAINED_GLASS_PANE.green())
-				.add(BlockItemIds.DYED_TERRACOTTA.green()).add(BlockIds.WALL_BANNER.green()).add(BlockItemIds.WOOL.green());
-
-		builder(ConventionalBlockTags.LIGHT_BLUE_DYED)
-				.add(BlockItemIds.BANNER.lightBlue()).add(BlockItemIds.BED.lightBlue()).add(BlockItemIds.DYED_CANDLE.lightBlue()).add(BlockItemIds.CARPET.lightBlue())
-				.add(BlockItemIds.CONCRETE.lightBlue()).add(BlockItemIds.CONCRETE_POWDER.lightBlue()).add(BlockItemIds.GLAZED_TERRACOTTA.lightBlue())
-				.add(BlockItemIds.DYED_SHULKER_BOX.lightBlue()).add(BlockItemIds.STAINED_GLASS.lightBlue()).add(BlockItemIds.STAINED_GLASS_PANE.lightBlue())
-				.add(BlockItemIds.DYED_TERRACOTTA.lightBlue()).add(BlockIds.WALL_BANNER.lightBlue()).add(BlockItemIds.WOOL.lightBlue());
-
-		builder(ConventionalBlockTags.LIGHT_GRAY_DYED)
-				.add(BlockItemIds.BANNER.lightGray()).add(BlockItemIds.BED.lightGray()).add(BlockItemIds.DYED_CANDLE.lightGray()).add(BlockItemIds.CARPET.lightGray())
-				.add(BlockItemIds.CONCRETE.lightGray()).add(BlockItemIds.CONCRETE_POWDER.lightGray()).add(BlockItemIds.GLAZED_TERRACOTTA.lightGray())
-				.add(BlockItemIds.DYED_SHULKER_BOX.lightGray()).add(BlockItemIds.STAINED_GLASS.lightGray()).add(BlockItemIds.STAINED_GLASS_PANE.lightGray())
-				.add(BlockItemIds.DYED_TERRACOTTA.lightGray()).add(BlockIds.WALL_BANNER.lightGray()).add(BlockItemIds.WOOL.lightGray());
-
-		builder(ConventionalBlockTags.LIME_DYED)
-				.add(BlockItemIds.BANNER.lime()).add(BlockItemIds.BED.lime()).add(BlockItemIds.DYED_CANDLE.lime()).add(BlockItemIds.CARPET.lime())
-				.add(BlockItemIds.CONCRETE.lime()).add(BlockItemIds.CONCRETE_POWDER.lime()).add(BlockItemIds.GLAZED_TERRACOTTA.lime())
-				.add(BlockItemIds.DYED_SHULKER_BOX.lime()).add(BlockItemIds.STAINED_GLASS.lime()).add(BlockItemIds.STAINED_GLASS_PANE.lime())
-				.add(BlockItemIds.DYED_TERRACOTTA.lime()).add(BlockIds.WALL_BANNER.lime()).add(BlockItemIds.WOOL.lime());
-
-		builder(ConventionalBlockTags.MAGENTA_DYED)
-				.add(BlockItemIds.BANNER.magenta()).add(BlockItemIds.BED.magenta()).add(BlockItemIds.DYED_CANDLE.magenta()).add(BlockItemIds.CARPET.magenta())
-				.add(BlockItemIds.CONCRETE.magenta()).add(BlockItemIds.CONCRETE_POWDER.magenta()).add(BlockItemIds.GLAZED_TERRACOTTA.magenta())
-				.add(BlockItemIds.DYED_SHULKER_BOX.magenta()).add(BlockItemIds.STAINED_GLASS.magenta()).add(BlockItemIds.STAINED_GLASS_PANE.magenta())
-				.add(BlockItemIds.DYED_TERRACOTTA.magenta()).add(BlockIds.WALL_BANNER.magenta()).add(BlockItemIds.WOOL.magenta());
-
-		builder(ConventionalBlockTags.ORANGE_DYED)
-				.add(BlockItemIds.BANNER.orange()).add(BlockItemIds.BED.orange()).add(BlockItemIds.DYED_CANDLE.orange()).add(BlockItemIds.CARPET.orange())
-				.add(BlockItemIds.CONCRETE.orange()).add(BlockItemIds.CONCRETE_POWDER.orange()).add(BlockItemIds.GLAZED_TERRACOTTA.orange())
-				.add(BlockItemIds.DYED_SHULKER_BOX.orange()).add(BlockItemIds.STAINED_GLASS.orange()).add(BlockItemIds.STAINED_GLASS_PANE.orange())
-				.add(BlockItemIds.DYED_TERRACOTTA.orange()).add(BlockIds.WALL_BANNER.orange()).add(BlockItemIds.WOOL.orange());
-
-		builder(ConventionalBlockTags.PINK_DYED)
-				.add(BlockItemIds.BANNER.pink()).add(BlockItemIds.BED.pink()).add(BlockItemIds.DYED_CANDLE.pink()).add(BlockItemIds.CARPET.pink())
-				.add(BlockItemIds.CONCRETE.pink()).add(BlockItemIds.CONCRETE_POWDER.pink()).add(BlockItemIds.GLAZED_TERRACOTTA.pink())
-				.add(BlockItemIds.DYED_SHULKER_BOX.pink()).add(BlockItemIds.STAINED_GLASS.pink()).add(BlockItemIds.STAINED_GLASS_PANE.pink())
-				.add(BlockItemIds.DYED_TERRACOTTA.pink()).add(BlockIds.WALL_BANNER.pink()).add(BlockItemIds.WOOL.pink());
-
-		builder(ConventionalBlockTags.PURPLE_DYED)
-				.add(BlockItemIds.BANNER.purple()).add(BlockItemIds.BED.purple()).add(BlockItemIds.DYED_CANDLE.purple()).add(BlockItemIds.CARPET.purple())
-				.add(BlockItemIds.CONCRETE.purple()).add(BlockItemIds.CONCRETE_POWDER.purple()).add(BlockItemIds.GLAZED_TERRACOTTA.purple())
-				.add(BlockItemIds.DYED_SHULKER_BOX.purple()).add(BlockItemIds.STAINED_GLASS.purple()).add(BlockItemIds.STAINED_GLASS_PANE.purple())
-				.add(BlockItemIds.DYED_TERRACOTTA.purple()).add(BlockIds.WALL_BANNER.purple()).add(BlockItemIds.WOOL.purple());
-
-		builder(ConventionalBlockTags.RED_DYED)
-				.add(BlockItemIds.BANNER.red()).add(BlockItemIds.BED.red()).add(BlockItemIds.DYED_CANDLE.red()).add(BlockItemIds.CARPET.red())
-				.add(BlockItemIds.CONCRETE.red()).add(BlockItemIds.CONCRETE_POWDER.red()).add(BlockItemIds.GLAZED_TERRACOTTA.red())
-				.add(BlockItemIds.DYED_SHULKER_BOX.red()).add(BlockItemIds.STAINED_GLASS.red()).add(BlockItemIds.STAINED_GLASS_PANE.red())
-				.add(BlockItemIds.DYED_TERRACOTTA.red()).add(BlockIds.WALL_BANNER.red()).add(BlockItemIds.WOOL.red());
-
-		builder(ConventionalBlockTags.WHITE_DYED)
-				.add(BlockItemIds.BANNER.white()).add(BlockItemIds.BED.white()).add(BlockItemIds.DYED_CANDLE.white()).add(BlockItemIds.CARPET.white())
-				.add(BlockItemIds.CONCRETE.white()).add(BlockItemIds.CONCRETE_POWDER.white()).add(BlockItemIds.GLAZED_TERRACOTTA.white())
-				.add(BlockItemIds.DYED_SHULKER_BOX.white()).add(BlockItemIds.STAINED_GLASS.white()).add(BlockItemIds.STAINED_GLASS_PANE.white())
-				.add(BlockItemIds.DYED_TERRACOTTA.white()).add(BlockIds.WALL_BANNER.white()).add(BlockItemIds.WOOL.white());
-
-		builder(ConventionalBlockTags.YELLOW_DYED)
-				.add(BlockItemIds.BANNER.yellow()).add(BlockItemIds.BED.yellow()).add(BlockItemIds.DYED_CANDLE.yellow()).add(BlockItemIds.CARPET.yellow())
-				.add(BlockItemIds.CONCRETE.yellow()).add(BlockItemIds.CONCRETE_POWDER.yellow()).add(BlockItemIds.GLAZED_TERRACOTTA.yellow())
-				.add(BlockItemIds.DYED_SHULKER_BOX.yellow()).add(BlockItemIds.STAINED_GLASS.yellow()).add(BlockItemIds.STAINED_GLASS_PANE.yellow())
-				.add(BlockItemIds.DYED_TERRACOTTA.yellow()).add(BlockIds.WALL_BANNER.yellow()).add(BlockItemIds.WOOL.yellow());
+		for (ColorCollection<ResourceKey<Block>> colorCollection : List.of(BlockIds.WALL_BANNER)) {
+			builder(ConventionalBlockTags.BLACK_DYED).add(colorCollection.black());
+			builder(ConventionalBlockTags.BLUE_DYED).add(colorCollection.blue());
+			builder(ConventionalBlockTags.BROWN_DYED).add(colorCollection.brown());
+			builder(ConventionalBlockTags.CYAN_DYED).add(colorCollection.cyan());
+			builder(ConventionalBlockTags.GRAY_DYED).add(colorCollection.gray());
+			builder(ConventionalBlockTags.GREEN_DYED).add(colorCollection.green());
+			builder(ConventionalBlockTags.LIGHT_BLUE_DYED).add(colorCollection.lightBlue());
+			builder(ConventionalBlockTags.LIGHT_GRAY_DYED).add(colorCollection.lightGray());
+			builder(ConventionalBlockTags.LIME_DYED).add(colorCollection.lime());
+			builder(ConventionalBlockTags.MAGENTA_DYED).add(colorCollection.magenta());
+			builder(ConventionalBlockTags.ORANGE_DYED).add(colorCollection.orange());
+			builder(ConventionalBlockTags.PINK_DYED).add(colorCollection.pink());
+			builder(ConventionalBlockTags.PURPLE_DYED).add(colorCollection.purple());
+			builder(ConventionalBlockTags.RED_DYED).add(colorCollection.red());
+			builder(ConventionalBlockTags.WHITE_DYED).add(colorCollection.white());
+			builder(ConventionalBlockTags.YELLOW_DYED).add(colorCollection.yellow());
+		}
 
 		builder(ConventionalBlockTags.DYED)
 				.addTag(ConventionalBlockTags.WHITE_DYED)
@@ -606,7 +554,8 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.add(BlockItemIds.MANGROVE_LOG)
 				.add(BlockItemIds.OAK_LOG)
 				.add(BlockItemIds.PALE_OAK_LOG)
-				.add(BlockItemIds.SPRUCE_LOG);
+				.add(BlockItemIds.SPRUCE_LOG)
+				.add(BlockItemIds.POPLAR_LOG);
 
 		builder(ConventionalBlockTags.NETHER_NATURAL_LOGS)
 				.add(BlockItemIds.CRIMSON_STEM)
@@ -626,6 +575,7 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.add(BlockItemIds.OAK_WOOD)
 				.add(BlockItemIds.PALE_OAK_WOOD)
 				.add(BlockItemIds.SPRUCE_WOOD)
+				.add(BlockItemIds.POPLAR_WOOD)
 				.add(BlockItemIds.CRIMSON_HYPHAE)
 				.add(BlockItemIds.WARPED_HYPHAE);
 
@@ -640,6 +590,7 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.add(BlockItemIds.STRIPPED_OAK_LOG)
 				.add(BlockItemIds.STRIPPED_PALE_OAK_LOG)
 				.add(BlockItemIds.STRIPPED_SPRUCE_LOG)
+				.add(BlockItemIds.STRIPPED_POPLAR_LOG)
 				.add(BlockItemIds.STRIPPED_CRIMSON_STEM)
 				.add(BlockItemIds.STRIPPED_WARPED_STEM);
 
@@ -653,6 +604,7 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.add(BlockItemIds.STRIPPED_OAK_WOOD)
 				.add(BlockItemIds.STRIPPED_PALE_OAK_WOOD)
 				.add(BlockItemIds.STRIPPED_SPRUCE_WOOD)
+				.add(BlockItemIds.STRIPPED_POPLAR_WOOD)
 				.add(BlockItemIds.STRIPPED_CRIMSON_HYPHAE)
 				.add(BlockItemIds.STRIPPED_WARPED_HYPHAE);
 	}
@@ -672,7 +624,8 @@ public final class BlockTagsGenerator extends FabricTagsProvider.BlockTagsProvid
 				.add(BlockItemIds.PIGLIN_HEAD)
 				.add(BlockIds.PIGLIN_WALL_HEAD)
 				.add(BlockItemIds.DRAGON_HEAD)
-				.add(BlockIds.DRAGON_WALL_HEAD);
+				.add(BlockIds.DRAGON_WALL_HEAD)
+				.addOptionalTag(BlockTags.SKULLS);
 	}
 
 	private void generateTagAlias() {

--- a/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagsGenerator.java
+++ b/fabric-convention-tags-v2/src/datagen/java/net/fabricmc/fabric/impl/tag/convention/datagen/generators/ItemTagsGenerator.java
@@ -733,8 +733,7 @@ public final class ItemTagsGenerator extends FabricTagsProvider.ItemTagsProvider
 				.add(ItemIds.GUNPOWDER);
 
 		builder(ConventionalItemTags.MUSHROOMS)
-				.add(BlockItemIds.RED_MUSHROOM)
-				.add(BlockItemIds.BROWN_MUSHROOM);
+				.addOptionalTag(ItemTags.MUSHROOMS);
 
 		builder(ConventionalItemTags.NETHER_STARS)
 				.add(ItemIds.NETHER_STAR);

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/black.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/black.json
@@ -11,7 +11,9 @@
     "minecraft:black_stained_glass",
     "minecraft:black_stained_glass_pane",
     "minecraft:black_terracotta",
-    "minecraft:black_wall_banner",
-    "minecraft:black_wool"
+    "minecraft:black_wool",
+    "minecraft:black_wool_slab",
+    "minecraft:black_wool_stairs",
+    "minecraft:black_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/blue.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/blue.json
@@ -11,7 +11,9 @@
     "minecraft:blue_stained_glass",
     "minecraft:blue_stained_glass_pane",
     "minecraft:blue_terracotta",
-    "minecraft:blue_wall_banner",
-    "minecraft:blue_wool"
+    "minecraft:blue_wool",
+    "minecraft:blue_wool_slab",
+    "minecraft:blue_wool_stairs",
+    "minecraft:blue_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/brown.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/brown.json
@@ -11,7 +11,9 @@
     "minecraft:brown_stained_glass",
     "minecraft:brown_stained_glass_pane",
     "minecraft:brown_terracotta",
-    "minecraft:brown_wall_banner",
-    "minecraft:brown_wool"
+    "minecraft:brown_wool",
+    "minecraft:brown_wool_slab",
+    "minecraft:brown_wool_stairs",
+    "minecraft:brown_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/cyan.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/cyan.json
@@ -11,7 +11,9 @@
     "minecraft:cyan_stained_glass",
     "minecraft:cyan_stained_glass_pane",
     "minecraft:cyan_terracotta",
-    "minecraft:cyan_wall_banner",
-    "minecraft:cyan_wool"
+    "minecraft:cyan_wool",
+    "minecraft:cyan_wool_slab",
+    "minecraft:cyan_wool_stairs",
+    "minecraft:cyan_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/gray.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/gray.json
@@ -11,7 +11,9 @@
     "minecraft:gray_stained_glass",
     "minecraft:gray_stained_glass_pane",
     "minecraft:gray_terracotta",
-    "minecraft:gray_wall_banner",
-    "minecraft:gray_wool"
+    "minecraft:gray_wool",
+    "minecraft:gray_wool_slab",
+    "minecraft:gray_wool_stairs",
+    "minecraft:gray_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/green.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/green.json
@@ -11,7 +11,9 @@
     "minecraft:green_stained_glass",
     "minecraft:green_stained_glass_pane",
     "minecraft:green_terracotta",
-    "minecraft:green_wall_banner",
-    "minecraft:green_wool"
+    "minecraft:green_wool",
+    "minecraft:green_wool_slab",
+    "minecraft:green_wool_stairs",
+    "minecraft:green_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/light_blue.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/light_blue.json
@@ -11,7 +11,9 @@
     "minecraft:light_blue_stained_glass",
     "minecraft:light_blue_stained_glass_pane",
     "minecraft:light_blue_terracotta",
-    "minecraft:light_blue_wall_banner",
-    "minecraft:light_blue_wool"
+    "minecraft:light_blue_wool",
+    "minecraft:light_blue_wool_slab",
+    "minecraft:light_blue_wool_stairs",
+    "minecraft:light_blue_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/light_gray.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/light_gray.json
@@ -11,7 +11,9 @@
     "minecraft:light_gray_stained_glass",
     "minecraft:light_gray_stained_glass_pane",
     "minecraft:light_gray_terracotta",
-    "minecraft:light_gray_wall_banner",
-    "minecraft:light_gray_wool"
+    "minecraft:light_gray_wool",
+    "minecraft:light_gray_wool_slab",
+    "minecraft:light_gray_wool_stairs",
+    "minecraft:light_gray_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/lime.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/lime.json
@@ -11,7 +11,9 @@
     "minecraft:lime_stained_glass",
     "minecraft:lime_stained_glass_pane",
     "minecraft:lime_terracotta",
-    "minecraft:lime_wall_banner",
-    "minecraft:lime_wool"
+    "minecraft:lime_wool",
+    "minecraft:lime_wool_slab",
+    "minecraft:lime_wool_stairs",
+    "minecraft:lime_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/magenta.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/magenta.json
@@ -11,7 +11,9 @@
     "minecraft:magenta_stained_glass",
     "minecraft:magenta_stained_glass_pane",
     "minecraft:magenta_terracotta",
-    "minecraft:magenta_wall_banner",
-    "minecraft:magenta_wool"
+    "minecraft:magenta_wool",
+    "minecraft:magenta_wool_slab",
+    "minecraft:magenta_wool_stairs",
+    "minecraft:magenta_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/orange.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/orange.json
@@ -11,7 +11,9 @@
     "minecraft:orange_stained_glass",
     "minecraft:orange_stained_glass_pane",
     "minecraft:orange_terracotta",
-    "minecraft:orange_wall_banner",
-    "minecraft:orange_wool"
+    "minecraft:orange_wool",
+    "minecraft:orange_wool_slab",
+    "minecraft:orange_wool_stairs",
+    "minecraft:orange_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/pink.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/pink.json
@@ -11,7 +11,9 @@
     "minecraft:pink_stained_glass",
     "minecraft:pink_stained_glass_pane",
     "minecraft:pink_terracotta",
-    "minecraft:pink_wall_banner",
-    "minecraft:pink_wool"
+    "minecraft:pink_wool",
+    "minecraft:pink_wool_slab",
+    "minecraft:pink_wool_stairs",
+    "minecraft:pink_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/purple.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/purple.json
@@ -11,7 +11,9 @@
     "minecraft:purple_stained_glass",
     "minecraft:purple_stained_glass_pane",
     "minecraft:purple_terracotta",
-    "minecraft:purple_wall_banner",
-    "minecraft:purple_wool"
+    "minecraft:purple_wool",
+    "minecraft:purple_wool_slab",
+    "minecraft:purple_wool_stairs",
+    "minecraft:purple_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/red.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/red.json
@@ -11,7 +11,9 @@
     "minecraft:red_stained_glass",
     "minecraft:red_stained_glass_pane",
     "minecraft:red_terracotta",
-    "minecraft:red_wall_banner",
-    "minecraft:red_wool"
+    "minecraft:red_wool",
+    "minecraft:red_wool_slab",
+    "minecraft:red_wool_stairs",
+    "minecraft:red_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/white.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/white.json
@@ -11,7 +11,9 @@
     "minecraft:white_stained_glass",
     "minecraft:white_stained_glass_pane",
     "minecraft:white_terracotta",
-    "minecraft:white_wall_banner",
-    "minecraft:white_wool"
+    "minecraft:white_wool",
+    "minecraft:white_wool_slab",
+    "minecraft:white_wool_stairs",
+    "minecraft:white_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/yellow.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/dyed/yellow.json
@@ -11,7 +11,9 @@
     "minecraft:yellow_stained_glass",
     "minecraft:yellow_stained_glass_pane",
     "minecraft:yellow_terracotta",
-    "minecraft:yellow_wall_banner",
-    "minecraft:yellow_wool"
+    "minecraft:yellow_wool",
+    "minecraft:yellow_wool_slab",
+    "minecraft:yellow_wool_stairs",
+    "minecraft:yellow_wall_banner"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/natural_logs/overworld.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/natural_logs/overworld.json
@@ -9,6 +9,7 @@
     "minecraft:mangrove_log",
     "minecraft:oak_log",
     "minecraft:pale_oak_log",
-    "minecraft:spruce_log"
+    "minecraft:spruce_log",
+    "minecraft:poplar_log"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/natural_woods.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/natural_woods.json
@@ -9,6 +9,7 @@
     "minecraft:oak_wood",
     "minecraft:pale_oak_wood",
     "minecraft:spruce_wood",
+    "minecraft:poplar_wood",
     "minecraft:crimson_hyphae",
     "minecraft:warped_hyphae"
   ]

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/ores.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/ores.json
@@ -39,6 +39,10 @@
     {
       "id": "#c:ores/quartz",
       "required": false
+    },
+    {
+      "id": "#minecraft:ores",
+      "required": false
     }
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/skulls.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/skulls.json
@@ -13,6 +13,10 @@
     "minecraft:piglin_head",
     "minecraft:piglin_wall_head",
     "minecraft:dragon_head",
-    "minecraft:dragon_wall_head"
+    "minecraft:dragon_wall_head",
+    {
+      "id": "#minecraft:skulls",
+      "required": false
+    }
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/stripped_logs.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/stripped_logs.json
@@ -10,6 +10,7 @@
     "minecraft:stripped_oak_log",
     "minecraft:stripped_pale_oak_log",
     "minecraft:stripped_spruce_log",
+    "minecraft:stripped_poplar_log",
     "minecraft:stripped_crimson_stem",
     "minecraft:stripped_warped_stem"
   ]

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/stripped_woods.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/block/stripped_woods.json
@@ -9,6 +9,7 @@
     "minecraft:stripped_oak_wood",
     "minecraft:stripped_pale_oak_wood",
     "minecraft:stripped_spruce_wood",
+    "minecraft:stripped_poplar_wood",
     "minecraft:stripped_crimson_hyphae",
     "minecraft:stripped_warped_hyphae"
   ]

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/mushrooms.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/mushrooms.json
@@ -1,6 +1,8 @@
 {
   "values": [
-    "minecraft:red_mushroom",
-    "minecraft:brown_mushroom"
+    {
+      "id": "#minecraft:mushrooms",
+      "required": false
+    }
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/natural_logs/overworld.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/natural_logs/overworld.json
@@ -9,6 +9,7 @@
     "minecraft:mangrove_log",
     "minecraft:oak_log",
     "minecraft:pale_oak_log",
-    "minecraft:spruce_log"
+    "minecraft:spruce_log",
+    "minecraft:poplar_log"
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/natural_woods.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/natural_woods.json
@@ -9,6 +9,7 @@
     "minecraft:oak_wood",
     "minecraft:pale_oak_wood",
     "minecraft:spruce_wood",
+    "minecraft:poplar_wood",
     "minecraft:crimson_hyphae",
     "minecraft:warped_hyphae"
   ]

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/ores.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/ores.json
@@ -39,6 +39,10 @@
     {
       "id": "#c:ores/quartz",
       "required": false
+    },
+    {
+      "id": "#minecraft:ores",
+      "required": false
     }
   ]
 }

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/stripped_logs.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/stripped_logs.json
@@ -10,6 +10,7 @@
     "minecraft:stripped_oak_log",
     "minecraft:stripped_pale_oak_log",
     "minecraft:stripped_spruce_log",
+    "minecraft:stripped_poplar_log",
     "minecraft:stripped_crimson_stem",
     "minecraft:stripped_warped_stem"
   ]

--- a/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/stripped_woods.json
+++ b/fabric-convention-tags-v2/src/generated/resources/data/c/tags/item/stripped_woods.json
@@ -9,6 +9,7 @@
     "minecraft:stripped_oak_wood",
     "minecraft:stripped_pale_oak_wood",
     "minecraft:stripped_spruce_wood",
+    "minecraft:stripped_poplar_wood",
     "minecraft:stripped_crimson_hyphae",
     "minecraft:stripped_warped_hyphae"
   ]

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalBlockTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalBlockTags.java
@@ -20,6 +20,7 @@ import net.minecraft.tags.BlockItemTags;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.ColorCollection;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 
 import net.fabricmc.fabric.impl.tag.convention.v2.TagRegistration;
@@ -225,6 +226,28 @@ public final class ConventionalBlockTags {
 	public static final TagKey<Block> RED_DYED = register("dyed/red");
 	public static final TagKey<Block> WHITE_DYED = register("dyed/white");
 	public static final TagKey<Block> YELLOW_DYED = register("dyed/yellow");
+
+	/**
+	 * Dyed color tags as a color collection, for convenience.
+	 */
+	public static final ColorCollection<TagKey<Block>> COLOR_DYED = new ColorCollection<>(
+			WHITE_DYED,
+			ORANGE_DYED,
+			MAGENTA_DYED,
+			LIGHT_BLUE_DYED,
+			YELLOW_DYED,
+			LIME_DYED,
+			PINK_DYED,
+			GRAY_DYED,
+			LIGHT_GRAY_DYED,
+			CYAN_DYED,
+			PURPLE_DYED,
+			BLUE_DYED,
+			BROWN_DYED,
+			GREEN_DYED,
+			RED_DYED,
+			BLACK_DYED
+	);
 
 	// Blocks that are for storing resources
 	/**


### PR DESCRIPTION
- Adds `minecraft:ores` to `c:ores`.
- Adds `minecraft:mushrooms` to `c:mushrooms`, replacing existing contents as the tags would be identical. (includes new Shelf Mushroom)
- Adds `minecraft:skulls` to `c:skulls`.
- Adds Poplar Logs and Wood to the various wood tags.
- Adds Wool Slabs and Stairs to the various dyeable tags.
	- Note: I changed the implementation of these tags to properly use the new `ColorCollection` class, (implementation further updated based on #5455). This should cut down on long-term maintenance of these tags.

I did not currently opt to alias any of the three new tags, as I saw some resistance to the idea. For reference:
- `minecraft:ores` is used exclusively in `blocks_motion`, alongside every other solid block in the game.
- `minecraft:mushrooms` is used exclusively for the Mushroom Stew recipe.
- `minecraft:skulls` is used exclusively in `minecraft:washed_away_by_fluids`, alongside every other solid non-block in the game. Note that vanilla does not include Wall Skull Blocks in their tag, so I would not recommend considering this one for aliasing in the future.

Fixes #5451 