### PR TITLE
Fix modded dimensions triggering experimental warning screen

### DIFF
--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/WorldDimensionsMixin.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/dimension/WorldDimensionsMixin.java
@@ -16,14 +16,25 @@
 
 package net.fabricmc.fabric.mixin.dimension;
 
+import java.util.Optional;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.mojang.datafixers.Products;
 import com.mojang.datafixers.kinds.App;
+import com.mojang.serialization.Lifecycle;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.core.RegistrationInfo;
+import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.dimension.LevelStem;
 import net.minecraft.world.level.levelgen.WorldDimensions;
@@ -32,6 +43,9 @@ import net.fabricmc.fabric.impl.dimension.FailSoftMapCodec;
 
 @Mixin(WorldDimensions.class)
 public class WorldDimensionsMixin {
+	@Unique
+	private static final ScopedValue<Registry<LevelStem>> REGISTRY = ScopedValue.newInstance();
+
 	/**
 	 * Fix the issue that cannot load world after uninstalling a dimension mod/datapack.
 	 * After uninstalling a dimension mod/datapack, the dimension config in `level.dat` file cannot be deserialized.
@@ -43,5 +57,31 @@ public class WorldDimensionsMixin {
 				new FailSoftMapCodec<>(ResourceKey.codec(Registries.LEVEL_STEM), LevelStem.CODEC)
 						.fieldOf("dimensions").forGetter(WorldDimensions::dimensions)
 		);
+	}
+
+	@WrapMethod(method = "bake")
+	private WorldDimensions.Complete wrapBakeToProvideContext(Registry<LevelStem> baseDimensions, Operation<WorldDimensions.Complete> original) {
+		return ScopedValue.where(REGISTRY, baseDimensions).call(() -> original.call(baseDimensions));
+	}
+
+	/**
+	 * Make all modded dimensions that are loaded from mod-provided resources use their defined lifecycle,
+	 * rather than always defaulting to experimental. This will hide the experimental message when creating/joining
+	 * a world.
+	 * This does not affect regular datapack provided changes or if mod overrides vanilla dimension!
+	 */
+	@Inject(method = "checkStability", at = @At("HEAD"), cancellable = true)
+	private static void betterModdedStabilityCheck(ResourceKey<LevelStem> key, LevelStem dimension, CallbackInfoReturnable<Lifecycle> cir) {
+		if (key.identifier().getNamespace().equals(Identifier.DEFAULT_NAMESPACE) || !REGISTRY.isBound()) {
+			return;
+		}
+
+		Optional<RegistrationInfo> registrationInfo = REGISTRY.get().registrationInfo(key);
+
+		if (registrationInfo.isEmpty() || registrationInfo.get().knownPackInfo().isEmpty()) {
+			return;
+		}
+
+		cir.setReturnValue(registrationInfo.get().lifecycle());
 	}
 }


### PR DESCRIPTION
Pretty simple mixin, which prevents json-defined dimensions provided by mods from triggering the experimental warning screen when creating/opening a world.

This implementation intentionally doesn't change the behaviour if mod overrides vanilla dimension or if the dimension is defined in an external datapack