### PR TITLE
Move Environmental Renderers to DimensionEffects

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/DimensionRenderingRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/DimensionRenderingRegistry.java
@@ -34,11 +34,16 @@ public interface DimensionRenderingRegistry {
 	/**
 	 * Registers the custom sky renderer for a {@link World}.
 	 *
-	 * <p>This overrides Vanilla's sky rendering.
+	 * <p>This overrides vanilla sky rendering. A renderer registered here takes precedence over
+	 * {@link FabricDimensionEffects#renderSky(WorldRenderContext)} for compatibility.
+	 *
 	 * @param key A {@link RegistryKey} for your {@link World}
 	 * @param renderer A {@link SkyRenderer} implementation
 	 * @throws IllegalArgumentException if key is already registered.
+	 * @deprecated Use a custom {@link DimensionEffects} implementation that overrides
+	 * {@link FabricDimensionEffects#renderSky(WorldRenderContext)} instead.
 	 */
+	@Deprecated
 	static void registerSkyRenderer(RegistryKey<World> key, SkyRenderer renderer) {
 		DimensionRenderingRegistryImpl.registerSkyRenderer(key, renderer);
 	}
@@ -46,11 +51,16 @@ public interface DimensionRenderingRegistry {
 	/**
 	 * Registers a custom weather renderer for a {@link World}.
 	 *
-	 * <p>This overrides Vanilla's weather rendering.
+	 * <p>This overrides vanilla weather rendering. A renderer registered here takes precedence over
+	 * {@link FabricDimensionEffects#renderWeather(WorldRenderContext)} for compatibility.
+	 *
 	 * @param key A RegistryKey for your {@link World}
 	 * @param renderer A {@link WeatherRenderer} implementation
 	 * @throws IllegalArgumentException if key is already registered.
+	 * @deprecated Use a custom {@link DimensionEffects} implementation that overrides
+	 * {@link FabricDimensionEffects#renderWeather(WorldRenderContext)} instead.
 	 */
+	@Deprecated
 	static void registerWeatherRenderer(RegistryKey<World> key, WeatherRenderer renderer) {
 		DimensionRenderingRegistryImpl.registerWeatherRenderer(key, renderer);
 	}
@@ -71,15 +81,20 @@ public interface DimensionRenderingRegistry {
 	/**
 	 * Registers a custom cloud renderer for a {@link World}.
 	 *
-	 * <p>This overrides Vanilla's cloud rendering.
+	 * <p>This overrides vanilla cloud rendering. A renderer registered here takes precedence over
+	 * {@link FabricDimensionEffects#renderCloud(WorldRenderContext)} for compatibility.
 	 *
 	 * @param key      A {@link RegistryKey} for your {@link World}
 	 * @param renderer A {@link CloudRenderer} implementation
 	 * @throws IllegalArgumentException if key is already registered.
+	 * @deprecated Use a custom {@link DimensionEffects} implementation that overrides
+	 * {@link FabricDimensionEffects#renderCloud(WorldRenderContext)} instead.
 	 */
+	@Deprecated
 	static void registerCloudRenderer(RegistryKey<World> key, CloudRenderer renderer) {
 		DimensionRenderingRegistryImpl.registerCloudRenderer(key, renderer);
 	}
+
 
 	/**
 	 * Gets the custom sky renderer for the given {@link World}.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/DimensionRenderingRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/DimensionRenderingRegistry.java
@@ -95,7 +95,6 @@ public interface DimensionRenderingRegistry {
 		DimensionRenderingRegistryImpl.registerCloudRenderer(key, renderer);
 	}
 
-
 	/**
 	 * Gets the custom sky renderer for the given {@link World}.
 	 *

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricDimensionEffects.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/FabricDimensionEffects.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.rendering.v1;
+
+/**
+ * Fabric-provided extensions for {@link net.minecraft.client.render.DimensionEffects}.
+ *
+ * <p>Note: This interface is automatically implemented on all
+ * {@link net.minecraft.client.render.DimensionEffects} instances via Mixin and interface injection.
+ *
+ * <p>Implement these methods on a custom {@link net.minecraft.client.render.DimensionEffects}
+ * to render dimension-specific sky, weather, or clouds. For per-world behavior, inspect
+ * {@link WorldRenderContext#world()}.
+ *
+ * <p>Legacy renderers registered through {@link DimensionRenderingRegistry} take precedence for
+ * compatibility. If no legacy renderer is registered for the current world, the corresponding
+ * method below is called. Returning {@code true} cancels vanilla rendering for that render pass;
+ * returning {@code false} allows vanilla rendering to continue.
+ */
+public interface FabricDimensionEffects {
+	/**
+	 * Renders custom sky content for this dimension.
+	 *
+	 * @param context context for the current world render
+	 * @return {@code true} to skip vanilla sky rendering, or {@code false} to allow it to continue
+	 */
+	default boolean renderSky(WorldRenderContext context) {
+		return false;
+	}
+
+	/**
+	 * Renders custom weather content for this dimension.
+	 *
+	 * @param context context for the current world render
+	 * @return {@code true} to skip vanilla weather rendering, or {@code false} to allow it to continue
+	 */
+	default boolean renderWeather(WorldRenderContext context) {
+		return false;
+	}
+
+	/**
+	 * Renders custom cloud content for this dimension.
+	 *
+	 * @param context context for the current world render
+	 * @return {@code true} to skip vanilla cloud rendering, or {@code false} to allow it to continue
+	 */
+	default boolean renderCloud(WorldRenderContext context) {
+		return false;
+	}
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DimensionEffectsMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DimensionEffectsMixin.java
@@ -16,11 +16,11 @@
 
 package net.fabricmc.fabric.mixin.client.rendering;
 
-import net.fabricmc.fabric.api.client.rendering.v1.FabricDimensionEffects;
+import org.spongepowered.asm.mixin.Mixin;
 
 import net.minecraft.client.render.DimensionEffects;
 
-import org.spongepowered.asm.mixin.Mixin;
+import net.fabricmc.fabric.api.client.rendering.v1.FabricDimensionEffects;
 
 @Mixin(DimensionEffects.class)
 public abstract class DimensionEffectsMixin implements FabricDimensionEffects {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DimensionEffectsMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/DimensionEffectsMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.client.rendering;
+
+import net.fabricmc.fabric.api.client.rendering.v1.FabricDimensionEffects;
+
+import net.minecraft.client.render.DimensionEffects;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(DimensionEffects.class)
+public abstract class DimensionEffectsMixin implements FabricDimensionEffects {
+}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -175,11 +175,13 @@ public abstract class WorldRendererMixin {
 
 	@Inject(at = @At("HEAD"), method = "renderWeather", cancellable = true)
 	private void renderWeather(LightmapTextureManager manager, float tickDelta, double x, double y, double z, CallbackInfo info) {
-		if (this.client.world != null) {
-			DimensionRenderingRegistry.WeatherRenderer renderer = DimensionRenderingRegistry.getWeatherRenderer(world.getRegistryKey());
+		DimensionRenderingRegistry.WeatherRenderer renderer = DimensionRenderingRegistry.getWeatherRenderer(world.getRegistryKey());
 
-			if (renderer != null) {
-				renderer.render(context);
+		if (renderer != null) {
+			renderer.render(context);
+			info.cancel();
+		} else if (this.client.world != null) {
+			if(this.client.world.getDimensionEffects().renderWeather(context)) {
 				info.cancel();
 			}
 		}
@@ -187,23 +189,25 @@ public abstract class WorldRendererMixin {
 
 	@Inject(at = @At("HEAD"), method = "renderClouds(Lnet/minecraft/client/util/math/MatrixStack;Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;FDDD)V", cancellable = true)
 	private void renderCloud(MatrixStack matrices, Matrix4f matrix4f, Matrix4f matrix4f2, float tickDelta, double cameraX, double cameraY, double cameraZ, CallbackInfo info) {
-		if (this.client.world != null) {
-			DimensionRenderingRegistry.CloudRenderer renderer = DimensionRenderingRegistry.getCloudRenderer(world.getRegistryKey());
+		DimensionRenderingRegistry.CloudRenderer renderer = DimensionRenderingRegistry.getCloudRenderer(world.getRegistryKey());
 
-			if (renderer != null) {
-				renderer.render(context);
-				info.cancel();
-			}
+		if (renderer != null) {
+			renderer.render(context);
+			info.cancel();
+		} else if (this.client.world != null) {
+			if (this.client.world.getDimensionEffects().renderCloud(context)) info.cancel();
 		}
 	}
 
 	@Inject(at = @At(value = "INVOKE", target = "Ljava/lang/Runnable;run()V", shift = At.Shift.AFTER, ordinal = 0), method = "renderSky(Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;FLnet/minecraft/client/render/Camera;ZLjava/lang/Runnable;)V", cancellable = true)
 	private void renderSky(Matrix4f matrix4f, Matrix4f matrix4f2, float tickDelta, Camera camera, boolean bl, Runnable runnable, CallbackInfo info) {
-		if (this.client.world != null) {
-			DimensionRenderingRegistry.SkyRenderer renderer = DimensionRenderingRegistry.getSkyRenderer(world.getRegistryKey());
+		DimensionRenderingRegistry.SkyRenderer renderer = DimensionRenderingRegistry.getSkyRenderer(world.getRegistryKey());
 
-			if (renderer != null) {
-				renderer.render(context);
+		if (renderer != null) {
+			renderer.render(context);
+			info.cancel();
+		} else if (this.client.world != null) {
+			if(this.client.world.getDimensionEffects().renderSky(context)) {
 				info.cancel();
 			}
 		}

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/WorldRendererMixin.java
@@ -181,7 +181,7 @@ public abstract class WorldRendererMixin {
 			renderer.render(context);
 			info.cancel();
 		} else if (this.client.world != null) {
-			if(this.client.world.getDimensionEffects().renderWeather(context)) {
+			if (this.client.world.getDimensionEffects().renderWeather(context)) {
 				info.cancel();
 			}
 		}
@@ -195,7 +195,9 @@ public abstract class WorldRendererMixin {
 			renderer.render(context);
 			info.cancel();
 		} else if (this.client.world != null) {
-			if (this.client.world.getDimensionEffects().renderCloud(context)) info.cancel();
+			if (this.client.world.getDimensionEffects().renderCloud(context)) {
+				info.cancel();
+			}
 		}
 	}
 
@@ -207,7 +209,7 @@ public abstract class WorldRendererMixin {
 			renderer.render(context);
 			info.cancel();
 		} else if (this.client.world != null) {
-			if(this.client.world.getDimensionEffects().renderSky(context)) {
+			if (this.client.world.getDimensionEffects().renderSky(context)) {
 				info.cancel();
 			}
 		}

--- a/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
+++ b/fabric-rendering-v1/src/client/resources/fabric-rendering-v1.mixins.json
@@ -11,6 +11,7 @@
     "CapeFeatureRendererMixin",
     "ClientWorldMixin",
     "DimensionEffectsAccessor",
+    "DimensionEffectsMixin",
     "EntityModelLayersAccessor",
     "EntityModelsMixin",
     "EntityRenderersMixin",

--- a/fabric-rendering-v1/src/client/resources/fabric.mod.json
+++ b/fabric-rendering-v1/src/client/resources/fabric.mod.json
@@ -24,6 +24,11 @@
     "fabric-rendering-v1.mixins.json"
   ],
   "custom": {
-    "fabric-api:module-lifecycle": "stable"
+    "fabric-api:module-lifecycle": "stable",
+    "loom:injected_interfaces": {
+      "net/minecraft/class_5294": [
+        "net/fabricmc/fabric/api/client/rendering/v1/FabricDimensionEffects"
+      ]
+    }
   }
 }

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/DimensionalRenderingTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/DimensionalRenderingTest.java
@@ -17,6 +17,7 @@
 package net.fabricmc.fabric.test.rendering.client;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+
 import org.joml.Matrix4f;
 
 import net.minecraft.client.render.BufferBuilder;
@@ -26,8 +27,6 @@ import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexFormat;
 import net.minecraft.client.render.VertexFormats;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ClientModInitializer;
@@ -37,54 +36,58 @@ import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 public class DimensionalRenderingTest implements ClientModInitializer {
 	private static final Identifier END_SKY = Identifier.ofVanilla("textures/block/dirt.png");
 
-	private static void render(WorldRenderContext context) {
-		RenderSystem.enableBlend();
-		RenderSystem.defaultBlendFunc();
-		RenderSystem.depthMask(false);
-		RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
-		RenderSystem.setShaderTexture(0, END_SKY);
-		Tessellator tessellator = Tessellator.getInstance();
-		BufferBuilder bufferBuilder = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
-
-		Matrix4f matrix4f = context.positionMatrix();
-		bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
-
-		bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -99.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -99.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
-
-		bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
-
-		bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 101.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
-
-		bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
-
-		bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-		bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
-		BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
-
-		RenderSystem.depthMask(true);
-		RenderSystem.disableBlend();
-	}
-
 	@Override
 	public void onInitializeClient() {
-		DimensionRenderingRegistry.registerSkyRenderer(RegistryKey.of(RegistryKeys.WORLD, Identifier.of("fabric_dimension", "void")), DimensionalRenderingTest::render);
-		DimensionRenderingRegistry.registerDimensionEffects(Identifier.of("fabric_dimension", "void"), new DimensionEffects.End());
+		DimensionRenderingRegistry.registerDimensionEffects(Identifier.of("fabric_dimension", "void"), new FabicVoidDimensionEffects());
+	}
+
+	private static class FabicVoidDimensionEffects extends DimensionEffects.End {
+		@Override
+		public boolean renderSky(WorldRenderContext context) {
+			RenderSystem.enableBlend();
+			RenderSystem.defaultBlendFunc();
+			RenderSystem.depthMask(false);
+			RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
+			RenderSystem.setShaderTexture(0, END_SKY);
+			Tessellator tessellator = Tessellator.getInstance();
+			BufferBuilder bufferBuilder = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+
+			Matrix4f matrix4f = context.positionMatrix();
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -99.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -99.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 101.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+			BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
+
+			RenderSystem.depthMask(true);
+			RenderSystem.disableBlend();
+
+			return true;
+		}
 	}
 }

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/DimensionalRenderingTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/DimensionalRenderingTest.java
@@ -17,7 +17,6 @@
 package net.fabricmc.fabric.test.rendering.client;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-
 import org.joml.Matrix4f;
 
 import net.minecraft.client.render.BufferBuilder;
@@ -34,60 +33,60 @@ import net.fabricmc.fabric.api.client.rendering.v1.DimensionRenderingRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 
 public class DimensionalRenderingTest implements ClientModInitializer {
-    private static final Identifier END_SKY = Identifier.ofVanilla("textures/block/dirt.png");
+	private static final Identifier END_SKY = Identifier.ofVanilla("textures/block/dirt.png");
 
-    @Override
-    public void onInitializeClient() {
-        DimensionRenderingRegistry.registerDimensionEffects(Identifier.of("fabric_dimension", "void"), new FabicVoidDimensionEffects());
-    }
+	@Override
+	public void onInitializeClient() {
+		DimensionRenderingRegistry.registerDimensionEffects(Identifier.of("fabric_dimension", "void"), new FabicVoidDimensionEffects());
+	}
 
-    private static class FabicVoidDimensionEffects extends DimensionEffects.End {
-        @Override
-        public boolean renderSky(WorldRenderContext context) {
-            RenderSystem.enableBlend();
-            RenderSystem.defaultBlendFunc();
-            RenderSystem.depthMask(false);
-            RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
-            RenderSystem.setShaderTexture(0, END_SKY);
-            Tessellator tessellator = Tessellator.getInstance();
-            BufferBuilder bufferBuilder = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+	private static class FabicVoidDimensionEffects extends DimensionEffects.End {
+		@Override
+		public boolean renderSky(WorldRenderContext context) {
+			RenderSystem.enableBlend();
+			RenderSystem.defaultBlendFunc();
+			RenderSystem.depthMask(false);
+			RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
+			RenderSystem.setShaderTexture(0, END_SKY);
+			Tessellator tessellator = Tessellator.getInstance();
+			BufferBuilder bufferBuilder = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
 
-            Matrix4f matrix4f = context.positionMatrix();
-            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+			Matrix4f matrix4f = context.positionMatrix();
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -99.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -99.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -99.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -99.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 101.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 101.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
-            BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+			BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
 
-            RenderSystem.depthMask(true);
-            RenderSystem.disableBlend();
+			RenderSystem.depthMask(true);
+			RenderSystem.disableBlend();
 
-            return true;
-        }
-    }
+			return true;
+		}
+	}
 }

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/DimensionalRenderingTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/DimensionalRenderingTest.java
@@ -34,60 +34,60 @@ import net.fabricmc.fabric.api.client.rendering.v1.DimensionRenderingRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 
 public class DimensionalRenderingTest implements ClientModInitializer {
-	private static final Identifier END_SKY = Identifier.ofVanilla("textures/block/dirt.png");
+    private static final Identifier END_SKY = Identifier.ofVanilla("textures/block/dirt.png");
 
-	@Override
-	public void onInitializeClient() {
-		DimensionRenderingRegistry.registerDimensionEffects(Identifier.of("fabric_dimension", "void"), new FabicVoidDimensionEffects());
-	}
+    @Override
+    public void onInitializeClient() {
+        DimensionRenderingRegistry.registerDimensionEffects(Identifier.of("fabric_dimension", "void"), new FabicVoidDimensionEffects());
+    }
 
-	private static class FabicVoidDimensionEffects extends DimensionEffects.End {
-		@Override
-		public boolean renderSky(WorldRenderContext context) {
-			RenderSystem.enableBlend();
-			RenderSystem.defaultBlendFunc();
-			RenderSystem.depthMask(false);
-			RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
-			RenderSystem.setShaderTexture(0, END_SKY);
-			Tessellator tessellator = Tessellator.getInstance();
-			BufferBuilder bufferBuilder = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+    private static class FabicVoidDimensionEffects extends DimensionEffects.End {
+        @Override
+        public boolean renderSky(WorldRenderContext context) {
+            RenderSystem.enableBlend();
+            RenderSystem.defaultBlendFunc();
+            RenderSystem.depthMask(false);
+            RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
+            RenderSystem.setShaderTexture(0, END_SKY);
+            Tessellator tessellator = Tessellator.getInstance();
+            BufferBuilder bufferBuilder = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
 
-			Matrix4f matrix4f = context.positionMatrix();
-			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+            Matrix4f matrix4f = context.positionMatrix();
+            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -99.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -99.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -99.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -99.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 101.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 101.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, -100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, 100.0f, 100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
 
-			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
-			bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
-			BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
+            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, -100.0f).texture(0.0F, 0.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, 100.0f, 100.0f).texture(0.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, 100.0f).texture(1.0F, 1.0F).color(255, 255, 255, 255);
+            bufferBuilder.vertex(matrix4f, -100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(255, 255, 255, 255);
+            BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
 
-			RenderSystem.depthMask(true);
-			RenderSystem.disableBlend();
+            RenderSystem.depthMask(true);
+            RenderSystem.disableBlend();
 
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
This PR deprecates the SkyRenderer, WeatherRenderer and CloudRenderer in favor of an interface injected approach in the DimensionEffects class. The old rendering method was limited to the particular world each renderer was individually registered too. Moving the rendering logic to the DimensionEffects allows any custom worlds to use the custom environmental rendering. For the sake of backward compatibility, the old deprecated environmental renderers are still wired in. The api will check these first before checking the DimensionEffects.

Use cases:

As stated above, moving the rendering logic to DimensionEffects allows for any custom world to use it by simply using setting the effects for the dimension.

Another use case is my own Dimensional Doors where each dimensional door pocket can have individualized environmental effects. This new api would make using another dimension's environmental rendering easier.