### PR TITLE
Fix datagen crash with non-fabric-api tag providers (closes #5431)

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/TagsProviderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/TagsProviderMixin.java
@@ -69,9 +69,14 @@ public class TagsProviderMixin<T> {
 		return ((TagBuilderHooks) builder).fabric_isReplaced();
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "ConstantValue"})
 	@WrapOperation(method = "lambda$run$2", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/CompletableFuture;allOf([Ljava/util/concurrent/CompletableFuture;)Ljava/util/concurrent/CompletableFuture;"))
 	private CompletableFuture<Void> addTagAliasGroupBuilders(CompletableFuture<?>[] cfs, Operation<CompletableFuture<Void>> original, @Local(argsOnly = true) CachedOutput cache) {
+		// exclude providers that don't use fabric API
+		if (!((Object) this instanceof FabricTagsProvider)) {
+			return original.call((Object) cfs);
+		}
+
 		// Note: no pattern matching instanceof so that we can cast directly to FabricTagsProvider<T> instead of a wildcard
 		Map<Identifier, FabricTagsProvider<T>.AliasGroupBuilder> builders = ((FabricTagsProvider<T>) (Object) this).getAliasGroupBuilders();
 		CompletableFuture<?>[] newFutures = Arrays.copyOf(cfs, cfs.length + builders.size());

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/tags/sound_event/test_equip_sounds.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/tags/sound_event/test_equip_sounds.json
@@ -1,0 +1,14 @@
+{
+  "values": [
+    "minecraft:item.armor.equip_turtle",
+    "minecraft:item.armor.equip_elytra",
+    "minecraft:item.armor.equip_leather",
+    "minecraft:item.armor.equip_chain",
+    "minecraft:item.armor.equip_copper",
+    "minecraft:item.armor.equip_iron",
+    "minecraft:item.armor.equip_gold",
+    "minecraft:item.armor.equip_diamond",
+    "minecraft:item.armor.equip_netherite",
+    "minecraft:item.armor.equip_generic"
+  ]
+}

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
@@ -26,6 +26,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
@@ -72,6 +73,8 @@ public class DataGeneratorTestContent implements ModInitializer {
 	// Empty registry
 	public static final ResourceKey<Registry<TestDatagenObject>> TEST_DATAGEN_DYNAMIC_EMPTY_REGISTRY_KEY =
 			ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath("fabric", "test_datagen_dynamic_empty"));
+
+	public static final TagKey<SoundEvent> EQUIP_SOUNDS = TagKey.create(Registries.SOUND_EVENT, Identifier.fromNamespaceAndPath(MOD_ID, "test_equip_sounds"));
 
 	@Override
 	public void onInitialize() {

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -56,11 +56,14 @@ import net.minecraft.data.recipes.RecipeCategory;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.data.recipes.RecipeProvider;
 import net.minecraft.data.registries.RegistryPatchGenerator;
+import net.minecraft.data.tags.KeyTagProvider;
 import net.minecraft.data.worldgen.BootstrapContext;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.RegistryFixedCodec;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
@@ -128,6 +131,7 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		pack.addProvider((output, registries) -> new TestItemTagsProvider(output, registries, blockTagsProvider));
 		pack.addProvider(TestBiomeTagsProvider::new);
 		pack.addProvider(TestGameEventTagsProvider::new);
+		pack.addProvider(TestVanillaSoundEventTagsProvider::new);
 
 		// TODO replace with a client only entrypoint with FMJ 2
 		if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
@@ -544,6 +548,35 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 			private static final Codec<Entry> CODEC = RecordCodecBuilder.create(instance -> instance.group(
 					RegistryFixedCodec.create(Registries.BIOME).fieldOf("biome").forGetter(Entry::biome)
 			).apply(instance, Entry::new));
+		}
+	}
+
+	/**
+	 * Ensure that vanilla generators that do not extend {@linkplain FabricTagsProvider} still work.
+	 * @see <a href="https://github.com/FabricMC/fabric-api/issues/5431">github-5431</a>
+	 */
+	private static class TestVanillaSoundEventTagsProvider extends KeyTagProvider<SoundEvent> {
+		private TestVanillaSoundEventTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider) {
+			super(output, Registries.SOUND_EVENT, lookupProvider);
+		}
+
+		private static ResourceKey<SoundEvent> key(Holder<SoundEvent> holder) {
+			return holder.unwrapKey().orElseThrow();
+		}
+
+		@Override
+		protected void addTags(HolderLookup.Provider registries) {
+			tag(DataGeneratorTestContent.EQUIP_SOUNDS)
+					.add(key(SoundEvents.ARMOR_EQUIP_TURTLE))
+					.add(key(SoundEvents.ARMOR_EQUIP_ELYTRA))
+					.add(key(SoundEvents.ARMOR_EQUIP_LEATHER))
+					.add(key(SoundEvents.ARMOR_EQUIP_CHAIN))
+					.add(key(SoundEvents.ARMOR_EQUIP_COPPER))
+					.add(key(SoundEvents.ARMOR_EQUIP_IRON))
+					.add(key(SoundEvents.ARMOR_EQUIP_GOLD))
+					.add(key(SoundEvents.ARMOR_EQUIP_DIAMOND))
+					.add(key(SoundEvents.ARMOR_EQUIP_NETHERITE))
+					.add(key(SoundEvents.ARMOR_EQUIP_GENERIC));
 		}
 	}
 }


### PR DESCRIPTION
Backport of #5494
---
Fixes a blind cast to `FabricTagsProvider` without first checking whether the object actually extends it.