### PR TITLE
Fix removed synced attachments being resent to every new tracker

### DIFF
--- a/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
+++ b/fabric-data-attachment-api-v1/src/main/java/net/fabricmc/fabric/mixin/attachment/AttachmentTargetsMixin.java
@@ -101,7 +101,8 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 
 			if (this.fabric_shouldTryToSync() && type.isSynced()) {
 				AttachmentChange change = new AttachmentChange(fabric_getSyncTargetInfo(), type, value);
-				acknowledgeSyncedEntry(type, change);
+				// a removal has to drop the entry, otherwise it gets resent to every new tracker
+				acknowledgeSyncedEntry(type, value == null ? null : change);
 				this.fabric_syncChange(type, change);
 			}
 		}
@@ -192,6 +193,10 @@ abstract class AttachmentTargetsMixin implements AttachmentTargetImpl {
 			syncedAttachments.remove(type);
 
 			if (fabric_shouldDeferSync()) {
+				if (deferredSyncedAttachments == null) {
+					deferredSyncedAttachments = Collections.newSetFromMap(new IdentityHashMap<>());
+				}
+
 				deferredSyncedAttachments.add(type);
 			}
 		} else {


### PR DESCRIPTION
Removing a synced attachment put a null-value change into `syncedAttachments` instead of removing the entry, so every new tracker got a pointless removal packet and the entry was never freed. Also adds a missing null check for `deferredSyncedAttachments` in the removal branch of `acknowledgeSyncedEntry`.

Tested with the new unit test in `CommonAttachmentTests` (./gradlew :fabric-data-attachment-api-v1:test).