### PR TITLE
Add registry bootstrapping utils in preparation for #5507

### DIFF
--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/BootstrapHelper.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/BootstrapHelper.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.registry;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.mojang.serialization.Lifecycle;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderOwner;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.registries.VanillaRegistries;
+import net.minecraft.resources.RegistryDataLoader;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.TagKey;
+
+public final class BootstrapHelper {
+	private BootstrapHelper() {
+	}
+
+	private static final class UniversalOwner<T> implements HolderOwner<T> {
+		@Override
+		public boolean canSerializeIn(HolderOwner<T> context) {
+			return true;
+		}
+	}
+
+	/// creates a {@link Holder.Reference} to stand in for a {@link Holder.Reference} not available when bootstrapping
+	/// @param <T> the type of the backing registry
+	/// @param key the key of the {@link Holder.Reference}
+	public static <T> Holder.Reference<T> createStandInReference(ResourceKey<T> key) {
+		return Holder.Reference.createStandAlone(new UniversalOwner<>(), key);
+	}
+
+	/// creates a {@link HolderSet.Named} to stand in for a {@link HolderSet.Named} not available when bootstrapping
+	/// @param <T> the type of the backing registry
+	/// @param key the key of the {@link HolderSet.Named}
+	public static <T> HolderSet.Named<T> createStandInHolderSet(TagKey<T> key) {
+		return HolderSet.emptyNamed(new UniversalOwner<>(), key);
+	}
+
+	/// Creates a lookup from a registry set builder.
+	/// the created lookup includes the vanilla bootstraps, as well as any bootstraps introduced by the setup function
+	/// @param setup the setup to run on the builder
+	public static HolderLookup.Provider createBootstrappingLookup(Consumer<RegistrySetBuilder> setup) {
+		return createEmptyBootstrappingLookup(registries -> setup.accept(registries.withVanillaBootstraps()));
+	}
+
+	/// Creates a lookup from a Consumer operating on a registry set builder.
+	/// the created lookup includes the result of any bootstraps introduced by the setup function
+	/// @param setup the setup to run on the builder
+	public static HolderLookup.Provider createEmptyBootstrappingLookup(Consumer<RegistrySetBuilder> setup) {
+		RegistrySetBuilder builder = new RegistrySetBuilder();
+
+		for (RegistryDataLoader.RegistryData<?> entry : DynamicRegistries.getBootstrappingRegistries()) {
+			builder.add(entry.key(), Lifecycle.stable(), Function.identity()::apply);
+		}
+
+		var setupBuilder = new RegistrySetBuilder();
+		setup.accept(setupBuilder);
+		builder.withBootstrapsFrom(setupBuilder);
+
+		HolderLookup.Provider registryLookup = builder.build(RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY));
+
+		if (registryLookup.lookup(Registries.BIOME).isPresent() && registryLookup.lookup(Registries.PLACED_FEATURE).isPresent()) {
+			VanillaRegistries.validateThatAllBiomeFeaturesHaveBiomeFilter(registryLookup);
+		}
+
+		return registryLookup;
+	}
+}

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/FabricRegistrySetBuilder.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/api/event/registry/FabricRegistrySetBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.registry;
+
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Lifecycle;
+
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.data.registries.VanillaRegistries;
+import net.minecraft.resources.ResourceKey;
+
+public interface FabricRegistrySetBuilder {
+	private RegistrySetBuilder self() {
+		return (RegistrySetBuilder) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void mergeToMap(Map<ResourceKey<?>, Pair<Lifecycle, RegistrySetBuilder.RegistryBootstrap<?>>> map, ResourceKey<?> key, Lifecycle lifecycle, RegistrySetBuilder.RegistryBootstrap<?> bootstrap) {
+		Pair<Lifecycle, RegistrySetBuilder.RegistryBootstrap<?>> current = map.get(key);
+
+		if (current == null) {
+			map.put(key, Pair.of(lifecycle, bootstrap));
+			return;
+		}
+
+		map.put(key, Pair.of(current.getFirst().add(lifecycle), registry -> {
+			((RegistrySetBuilder.RegistryBootstrap<Object>) current.getSecond()).run(registry);
+			((RegistrySetBuilder.RegistryBootstrap<Object>) bootstrap).run(registry);
+		}));
+	}
+
+	/// Adds all bootstraps from others to this and applies the most severe lifecycle to this.
+	/// @param others {@link RegistrySetBuilder}s to source bootstrap functions from
+	/// @return this builder
+	@SuppressWarnings("unchecked")
+	default RegistrySetBuilder withBootstrapsFrom(RegistrySetBuilder... others) {
+		List<RegistrySetBuilder.RegistryStub<?>> entries = List.copyOf(self().entries);
+		self().entries.clear();
+		Map<ResourceKey<?>, Pair<Lifecycle, RegistrySetBuilder.RegistryBootstrap<?>>> combinedEntries = new IdentityHashMap<>();
+
+		for (RegistrySetBuilder.RegistryStub<?> entry : entries) {
+			mergeToMap(combinedEntries, entry.key(), entry.lifecycle(), entry.bootstrap());
+		}
+
+		for (RegistrySetBuilder other : others) {
+			for (RegistrySetBuilder.RegistryStub<?> entry : other.entries) {
+				mergeToMap(combinedEntries, entry.key(), entry.lifecycle(), entry.bootstrap());
+			}
+		}
+
+		for (Map.Entry<ResourceKey<?>, Pair<Lifecycle, RegistrySetBuilder.RegistryBootstrap<?>>> entry : combinedEntries.entrySet()) {
+			self().add(
+					(ResourceKey<? extends Registry<Object>>) entry.getKey(),
+					entry.getValue().getFirst(),
+					(RegistrySetBuilder.RegistryBootstrap<Object>) entry.getValue().getSecond()
+			);
+		}
+
+		return self();
+	}
+
+	/// Adds all bootstraps from {@code VanillaRegistries.BUILDER} to this and applies the most severe lifecycle to this.
+	/// @return this builder
+	default RegistrySetBuilder withVanillaBootstraps() {
+		return withBootstrapsFrom(VanillaRegistries.BUILDER);
+	}
+}

--- a/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.classtweaker
+++ b/fabric-registry-sync-v0/src/main/resources/fabric-registry-sync-v0.classtweaker
@@ -8,3 +8,8 @@ accessible	field	net/minecraft/core/RegistrySynchronization	NETWORKABLE_REGISTRI
 mutable	field	net/minecraft/core/RegistrySynchronization	NETWORKABLE_REGISTRIES	Ljava/util/Set;
 accessible field net/minecraft/resources/RegistryLoadTask registry Lnet/minecraft/core/WritableRegistry;
 transitive-inject-interface	net/minecraft/core/Registry	net/fabricmc/fabric/api/event/registry/FabricRegistry
+accessible field net/minecraft/core/RegistrySetBuilder entries Ljava/util/List;
+accessible class net/minecraft/core/RegistrySetBuilder$RegistryStub
+transitive-inject-interface net/minecraft/core/RegistrySetBuilder net/fabricmc/fabric/api/event/registry/FabricRegistrySetBuilder
+accessible field net/minecraft/data/registries/VanillaRegistries BUILDER Lnet/minecraft/core/RegistrySetBuilder;
+accessible method net/minecraft/data/registries/VanillaRegistries validateThatAllBiomeFeaturesHaveBiomeFilter (Lnet/minecraft/core/HolderLookup$Provider;)V

--- a/fabric-registry-sync-v0/src/test/java/net/fabricmc/fabric/test/registry/sync/BootstrapHelperTest.java
+++ b/fabric-registry-sync-v0/src/test/java/net/fabricmc/fabric/test/registry/sync/BootstrapHelperTest.java
@@ -27,12 +27,20 @@ import org.junit.jupiter.api.Test;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.features.CaveFeatures;
 import net.minecraft.data.worldgen.features.MiscOverworldFeatures;
 import net.minecraft.data.worldgen.placement.MiscOverworldPlacements;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.Bootstrap;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.valueproviders.ConstantFloat;
+import net.minecraft.util.valueproviders.ConstantInt;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.configurations.LargeDripstoneConfiguration;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
 import net.fabricmc.fabric.api.event.registry.BootstrapHelper;
@@ -58,5 +66,29 @@ public class BootstrapHelperTest {
 		RegistryOps<JsonElement> ops = registries.createSerializationContext(JsonOps.INSTANCE);
 		Assertions.assertDoesNotThrow(() -> PlacedFeature.CODEC.encodeStart(ops, ops.getter(Registries.PLACED_FEATURE).orElseThrow().getOrThrow(MiscOverworldPlacements.BLUE_ICE)).getOrThrow());
 		Assertions.assertDoesNotThrow(() -> PlacedFeature.CODEC.encodeStart(ops, ops.getter(Registries.PLACED_FEATURE).orElseThrow().getOrThrow(MiscOverworldPlacements.DISK_GRAVEL)).getOrThrow());
+	}
+
+	@Test
+	void testFauxHolderSet() {
+		HolderSet.Named<Block> fakeTag = BootstrapHelper.createStandInHolderSet(BlockTags.ALL_SIGNS);
+		HolderLookup.Provider registries = BootstrapHelper.createEmptyBootstrappingLookup(pendingRegistries -> {
+			pendingRegistries.add(Registries.CONFIGURED_FEATURE, registry -> {
+				registry.register(CaveFeatures.LARGE_DRIPSTONE, new ConfiguredFeature<>(Feature.LARGE_DRIPSTONE, new LargeDripstoneConfiguration(
+						fakeTag,
+						47,
+						ConstantInt.of(14),
+						ConstantFloat.of(10f),
+						.9f,
+						ConstantFloat.of(5f),
+						ConstantFloat.of(5f),
+						ConstantFloat.of(1f),
+						50,
+						4f
+				)));
+			});
+		});
+
+		RegistryOps<JsonElement> ops = registries.createSerializationContext(JsonOps.INSTANCE);
+		Assertions.assertDoesNotThrow(() -> ConfiguredFeature.CODEC.encodeStart(ops, ops.getter(Registries.CONFIGURED_FEATURE).orElseThrow().getOrThrow(CaveFeatures.LARGE_DRIPSTONE)).getOrThrow());
 	}
 }

--- a/fabric-registry-sync-v0/src/test/java/net/fabricmc/fabric/test/registry/sync/BootstrapHelperTest.java
+++ b/fabric-registry-sync-v0/src/test/java/net/fabricmc/fabric/test/registry/sync/BootstrapHelperTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.registry.sync;
+
+import java.util.List;
+
+import com.google.gson.JsonElement;
+import com.mojang.serialization.JsonOps;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.features.MiscOverworldFeatures;
+import net.minecraft.data.worldgen.placement.MiscOverworldPlacements;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+
+import net.fabricmc.fabric.api.event.registry.BootstrapHelper;
+
+public class BootstrapHelperTest {
+	@BeforeAll
+	static void beforeAll() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+	}
+
+	@Test
+	void testFauxHolder() {
+		Holder.Reference<ConfiguredFeature<?, ?>> fakeFeature = BootstrapHelper.createStandInReference(MiscOverworldFeatures.BLUE_ICE);
+		Holder.Reference<ConfiguredFeature<?, ?>> fakeFeature2 = BootstrapHelper.createStandInReference(MiscOverworldFeatures.DISK_GRAVEL);
+		HolderLookup.Provider registries = BootstrapHelper.createEmptyBootstrappingLookup(pendingRegistries -> {
+			pendingRegistries.add(Registries.PLACED_FEATURE, registry -> {
+				registry.register(MiscOverworldPlacements.BLUE_ICE, new PlacedFeature(fakeFeature, List.of()));
+				registry.register(MiscOverworldPlacements.DISK_GRAVEL, new PlacedFeature(fakeFeature2, List.of()));
+			});
+		});
+
+		RegistryOps<JsonElement> ops = registries.createSerializationContext(JsonOps.INSTANCE);
+		Assertions.assertDoesNotThrow(() -> PlacedFeature.CODEC.encodeStart(ops, ops.getter(Registries.PLACED_FEATURE).orElseThrow().getOrThrow(MiscOverworldPlacements.BLUE_ICE)).getOrThrow());
+		Assertions.assertDoesNotThrow(() -> PlacedFeature.CODEC.encodeStart(ops, ops.getter(Registries.PLACED_FEATURE).orElseThrow().getOrThrow(MiscOverworldPlacements.DISK_GRAVEL)).getOrThrow());
+	}
+}

--- a/fabric-registry-sync-v0/src/test/java/net/fabricmc/fabric/test/registry/sync/FabricRegistrySetBuilderTest.java
+++ b/fabric-registry-sync-v0/src/test/java/net/fabricmc/fabric/test/registry/sync/FabricRegistrySetBuilderTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.registry.sync;
+
+import com.mojang.serialization.Lifecycle;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.ClientAsset;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.entity.animal.chicken.ChickenVariant;
+import net.minecraft.world.entity.animal.chicken.ChickenVariants;
+import net.minecraft.world.entity.variant.ModelAndTexture;
+import net.minecraft.world.entity.variant.SpawnPrioritySelectors;
+
+import net.fabricmc.fabric.api.event.registry.BootstrapHelper;
+
+public class FabricRegistrySetBuilderTest {
+	@BeforeAll
+	static void beforeAll() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+	}
+
+	@Test
+	void testSetBuilderLifecycle() {
+		HolderLookup.Provider registries = BootstrapHelper.createEmptyBootstrappingLookup(pendingRegistries -> {
+			pendingRegistries.add(Registries.CHICKEN_VARIANT, Lifecycle.experimental(), _ -> {
+			});
+			pendingRegistries.withBootstrapsFrom(new RegistrySetBuilder().add(Registries.CHICKEN_VARIANT, Lifecycle.stable(), _ -> {
+			}));
+		});
+
+		Assertions.assertEquals(Lifecycle.experimental(), registries.allRegistriesLifecycle());
+
+		HolderLookup.Provider registries2 = BootstrapHelper.createEmptyBootstrappingLookup(pendingRegistries -> {
+			pendingRegistries.add(Registries.CHICKEN_VARIANT, Lifecycle.stable(), _ -> {
+			});
+			pendingRegistries.withBootstrapsFrom(new RegistrySetBuilder().add(Registries.CHICKEN_VARIANT, Lifecycle.stable(), _ -> {
+			}));
+		});
+
+		Assertions.assertEquals(Lifecycle.stable(), registries2.allRegistriesLifecycle());
+
+		HolderLookup.Provider registries3 = BootstrapHelper.createEmptyBootstrappingLookup(pendingRegistries -> {
+			pendingRegistries.add(Registries.CHICKEN_VARIANT, Lifecycle.deprecated(400), _ -> {
+			});
+			pendingRegistries.withBootstrapsFrom(new RegistrySetBuilder().add(Registries.CHICKEN_VARIANT, Lifecycle.stable(), _ -> {
+			}));
+			pendingRegistries.withBootstrapsFrom(new RegistrySetBuilder().add(Registries.CHICKEN_VARIANT, Lifecycle.deprecated(300), _ -> {
+			}));
+		});
+		Assertions.assertInstanceOf(Lifecycle.Deprecated.class, registries3.allRegistriesLifecycle());
+		Assertions.assertEquals(300, ((Lifecycle.Deprecated) registries3.allRegistriesLifecycle()).since());
+	}
+
+	@Test
+	void testBuilderMerging() {
+		HolderLookup.Provider registries = BootstrapHelper.createEmptyBootstrappingLookup(pendingRegistries -> {
+			pendingRegistries.withBootstrapsFrom(new RegistrySetBuilder().add(Registries.CHICKEN_VARIANT, Lifecycle.stable(), registry -> {
+				registry.register(ChickenVariants.COLD, new ChickenVariant(new ModelAndTexture<>(ChickenVariant.ModelType.COLD, Identifier.withDefaultNamespace("idk")), new ClientAsset.ResourceTexture(Identifier.withDefaultNamespace("idk")), SpawnPrioritySelectors.EMPTY));
+			}));
+
+			pendingRegistries.withBootstrapsFrom(new RegistrySetBuilder().add(Registries.CHICKEN_VARIANT, Lifecycle.stable(), registry -> {
+				registry.register(ChickenVariants.TEMPERATE, new ChickenVariant(new ModelAndTexture<>(ChickenVariant.ModelType.COLD, Identifier.withDefaultNamespace("idk")), new ClientAsset.ResourceTexture(Identifier.withDefaultNamespace("idk")), SpawnPrioritySelectors.EMPTY));
+			}));
+		});
+
+		Assertions.assertTrue(registries.lookup(Registries.CHICKEN_VARIANT).isPresent());
+		Assertions.assertTrue(registries.lookup(Registries.CHICKEN_VARIANT).flatMap(r -> r.get(ChickenVariants.TEMPERATE)).isPresent());
+		Assertions.assertTrue(registries.lookup(Registries.CHICKEN_VARIANT).flatMap(r -> r.get(ChickenVariants.COLD)).isPresent());
+		Assertions.assertTrue(registries.lookup(Registries.CHICKEN_VARIANT).flatMap(r -> r.get(ChickenVariants.WARM)).isEmpty());
+	}
+}

--- a/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.classtweaker
+++ b/fabric-transitive-access-wideners-v1/src/main/resources/fabric-transitive-access-wideners-v1.classtweaker
@@ -147,6 +147,10 @@ transitive-accessible   method  net/minecraft/data/worldgen/biome/EndBiomes base
 
 transitive-accessible   method  net/minecraft/data/worldgen/biome/NetherBiomes baseBiome ()Lnet/minecraft/world/level/biome/Biome$BiomeBuilder;
 
+# Vanilla Registry Bootstraps
+transitive-accessible field net/minecraft/data/registries/VanillaRegistries BUILDER Lnet/minecraft/core/RegistrySetBuilder;
+transitive-accessible method net/minecraft/data/registries/VanillaRegistries validateThatAllBiomeFeaturesHaveBiomeFilter (Lnet/minecraft/core/HolderLookup$Provider;)V
+
 ### Generated access wideners below
 # Constructors of non-abstract block classes
 transitive-accessible method net/minecraft/world/level/block/AttachedStemBlock <init> (Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/tags/TagKey;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V

--- a/fabric-transitive-access-wideners-v1/template.classtweaker
+++ b/fabric-transitive-access-wideners-v1/template.classtweaker
@@ -142,4 +142,8 @@ transitive-accessible   method  net/minecraft/data/worldgen/biome/EndBiomes base
 
 transitive-accessible   method  net/minecraft/data/worldgen/biome/NetherBiomes baseBiome ()Lnet/minecraft/world/level/biome/Biome$BiomeBuilder;
 
+# Vanilla Registry Bootstraps
+transitive-accessible field net/minecraft/data/registries/VanillaRegistries BUILDER Lnet/minecraft/core/RegistrySetBuilder;
+transitive-accessible method net/minecraft/data/registries/VanillaRegistries validateThatAllBiomeFeaturesHaveBiomeFilter (Lnet/minecraft/core/HolderLookup$Provider;)V
+
 ### Generated access wideners below


### PR DESCRIPTION
With #5507 adding runtime resource additions, it stands to reason that modders may want to bootstrap registries before registry context is available in order to serialize generated data to json for virtual resource packs. This pr copies previously internal code in FabricDatagenHelper into registry sync, to allow modders to easily create bootstrap lookups for serialization in contexts without full registry access. A later pr could migrate datagen to use this code, removing the duplication, as datagen already depends on reg sync