### PR TITLE
Fix `getCapacity` on an empty slot using air's capacity

### DIFF
--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ContainerSlotWrapper.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/ContainerSlotWrapper.java
@@ -123,7 +123,7 @@ class ContainerSlotWrapper extends SingleStackStorage {
 			return 1;
 		}
 
-		return Math.min(storage.container.getMaxStackSize(), ItemVariantImpl.getMaxStackSize(variant));
+		return variant.isBlank() ? storage.container.getMaxStackSize() : storage.container.getMaxStackSize(variant.toStack());
 	}
 
 	// We override updateSnapshots to also schedule a setChanged call for the backing inventory.

--- a/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/ContainerSlotWrapperTest.java
+++ b/fabric-transfer-api-v1/src/test/java/net/fabricmc/fabric/test/transfer/unittests/ContainerSlotWrapperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.transfer.unittests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+import net.fabricmc.fabric.api.transfer.v1.item.ContainerStorage;
+
+class ContainerSlotWrapperTest extends AbstractTransferApiTest {
+	@BeforeAll
+	static void beforeAll() {
+		bootstrap();
+	}
+
+	@Test
+	public void testGetCapacity() {
+		SimpleContainer simpleContainer = new SimpleContainer(3);
+		simpleContainer.setItem(0, new ItemStack(Items.DIRT));
+		simpleContainer.setItem(1, new ItemStack(Items.DIAMOND_PICKAXE));
+
+		ContainerStorage storage = ContainerStorage.of(simpleContainer, null);
+
+		assertEquals(64, storage.getSlot(0).getCapacity());
+		assertEquals(1, storage.getSlot(1).getCapacity());
+		assertEquals(99, storage.getSlot(2).getCapacity(), "Empty slots report the full capacity");
+	}
+}


### PR DESCRIPTION
Currently using `ContainerStorage.getSlot(slot).getCapacity()` on an empty slot returns 64, even if the container has a max stack size of 99. This is because `ContainerSlotWrapper` takes the minimum stack size of the stack *and* the current item, which in this case is air.

Instead, we should do the same as [NeoForge](https://github.com/neoforged/NeoForge/blob/ebd6aed98b7dc23e2b7868c2bc3b5db866347233/src/main/java/net/neoforged/neoforge/transfer/item/VanillaContainerWrapper.java#L188) and use `Container.getMaxStackSize()` for blank items (air), and `Container.getMaxStackSize(ItemStack)` otherwise.