### PR TITLE
Make `BlockModelGenerators`'s `PropertyDispatch` constants public

### DIFF
--- a/fabric-data-generation-api-v1/build.gradle
+++ b/fabric-data-generation-api-v1/build.gradle
@@ -112,6 +112,12 @@ tasks.register('generateClassTweaker') {
 			out += "transitive-accessible\tmethod\t${owner}\t${name}\t${desc}\n"
 		}
 
+		visitStaticFinalFields(classes["net/minecraft/client/data/models/BlockModelGenerators"]) { name, desc, owner ->
+			if (desc == "Lnet/minecraft/client/data/models/blockstates/PropertyDispatch;") {
+				out += "transitive-accessible\tfield\t${owner}\t${name}\t${desc}\n"
+			}
+		}
+
 		visitMethods(classes["net/minecraft/data/loot/BlockLootSubProvider"]) { name, desc, owner ->
 			out += "transitive-accessible\tmethod\t${owner}\t${name}\t${desc}\n"
 		}
@@ -158,6 +164,16 @@ static def visitFinalMethods(ClassNode classNode, closure) {
 			return
 
 		if (it.name.startsWith("<"))
+			return
+
+		closure(it.name, it.desc, classNode.name)
+	}
+}
+
+static def visitStaticFinalFields(ClassNode classNode, closure) {
+	classNode.fields.forEach {
+		int access = Opcodes.ACC_STATIC | Opcodes.ACC_FINAL
+		if ((it.access & access) != access || (it.access & Opcodes.ACC_PUBLIC) != 0)
 			return
 
 		closure(it.name, it.desc, classNode.name)

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.classtweaker
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.classtweaker
@@ -319,6 +319,11 @@ transitive-accessible	method	net/minecraft/client/data/models/BlockModelGenerato
 transitive-accessible	method	net/minecraft/client/data/models/BlockModelGenerators	generateSimpleSpecialItemModel	(Lnet/minecraft/world/level/block/Block;Ljava/util/Optional;Lnet/minecraft/client/renderer/special/SpecialModelRenderer$Unbaked;)V
 transitive-accessible	method	net/minecraft/client/data/models/BlockModelGenerators	createCopperChainItem	(Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/Item;)V
 transitive-accessible	method	net/minecraft/client/data/models/BlockModelGenerators	createCandleAndCandleCake	(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/Block;)V
+transitive-accessible	field	net/minecraft/client/data/models/BlockModelGenerators	ROTATION_FACING	Lnet/minecraft/client/data/models/blockstates/PropertyDispatch;
+transitive-accessible	field	net/minecraft/client/data/models/BlockModelGenerators	ROTATIONS_COLUMN_WITH_FACING	Lnet/minecraft/client/data/models/blockstates/PropertyDispatch;
+transitive-accessible	field	net/minecraft/client/data/models/BlockModelGenerators	ROTATION_TORCH	Lnet/minecraft/client/data/models/blockstates/PropertyDispatch;
+transitive-accessible	field	net/minecraft/client/data/models/BlockModelGenerators	ROTATION_HORIZONTAL_FACING_ALT	Lnet/minecraft/client/data/models/blockstates/PropertyDispatch;
+transitive-accessible	field	net/minecraft/client/data/models/BlockModelGenerators	ROTATION_HORIZONTAL_FACING	Lnet/minecraft/client/data/models/blockstates/PropertyDispatch;
 transitive-accessible	method	net/minecraft/data/loot/BlockLootSubProvider	hasSilkTouch	()Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition$Builder;
 transitive-accessible	method	net/minecraft/data/loot/BlockLootSubProvider	doesNotHaveSilkTouch	()Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition$Builder;
 transitive-accessible	method	net/minecraft/data/loot/BlockLootSubProvider	hasShears	()Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition$Builder;


### PR DESCRIPTION
This adds access wideners to all `static final PropertyDispatch<_>` fields on `BlockModelGenerators`. These are useful when constructing new `MultiVariantGenerator`s that don't fit into an existing template (e.g. `createRotatableColumn` or `createHorizontallyRotatedBlock`), but still use common block state properties.