### PR TITLE
[1.21.11] Extend `TooltipFlag` to allow for `shouldDisplayAllInformation` (Backport of #5483)

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricTooltipFlag.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricTooltipFlag.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.item.v1;
+
+/// General-purpose Fabric-provided extensions for [net.minecraft.world.item.TooltipFlag].
+///
+/// Note: This interface is automatically implemented on all tooltip flags via interface injection.
+public interface FabricTooltipFlag {
+	/// {@return all information that it may show under varying circumstances}
+	///
+	/// Modded tooltips often have requirements to hold keys like Shift or Ctrl in order
+	/// to see more information. With this flag enabled, all information provided
+	/// by this tooltip should be shown regardless of whether a key is held.
+	default boolean shouldDisplayAllInformation() {
+		return false;
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/TooltipFlagMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/TooltipFlagMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.item;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.world.item.TooltipFlag;
+
+import net.fabricmc.fabric.api.item.v1.FabricTooltipFlag;
+
+@Mixin(TooltipFlag.class)
+public class TooltipFlagMixin implements FabricTooltipFlag {
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/TooltipFlagMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/TooltipFlagMixin.java
@@ -23,5 +23,5 @@ import net.minecraft.world.item.TooltipFlag;
 import net.fabricmc.fabric.api.item.v1.FabricTooltipFlag;
 
 @Mixin(TooltipFlag.class)
-public class TooltipFlagMixin implements FabricTooltipFlag {
+public interface TooltipFlagMixin extends FabricTooltipFlag {
 }

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
@@ -19,7 +19,8 @@
     "ItemStackMixin",
     "LivingEntityMixin",
     "BuiltInRegistriesMixin",
-    "RegistryDataLoaderMixin"
+    "RegistryDataLoaderMixin",
+    "TooltipFlagMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-item-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/main/resources/fabric.mod.json
@@ -34,7 +34,8 @@
       "net/minecraft/class_1792": ["net/fabricmc/fabric/api/item/v1/FabricItem"],
       "net/minecraft/class_1792\u0024class_1793": ["net/fabricmc/fabric/api/item/v1/FabricItem\u0024Settings"],
       "net/minecraft/class_1799": ["net/fabricmc/fabric/api/item/v1/FabricItemStack"],
-      "net/minecraft/class_9323\u0024class_9324": ["net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder"]
+      "net/minecraft/class_9323\u0024class_9324": ["net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder"],
+      "net/minecraft/class_1836": ["net/fabricmc/fabric/api/item/v1/FabricTooltipFlag"]
     }
   }
 }


### PR DESCRIPTION
Backport of #5483 to 1.21.11, as requested by mezz.