### PR TITLE
[1.21.1] Extend `TooltipFlag` to allow for `shouldDisplayAllInformation` (Backport of #5483)

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricTooltipType.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/FabricTooltipType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.item.v1;
+
+/// General-purpose Fabric-provided extensions for [net.minecraft.item.tooltip.TooltipType].
+///
+/// Note: This interface is automatically implemented on all tooltip flags via interface injection.
+public interface FabricTooltipType {
+	/// {@return all information that it may show under varying circumstances}
+	///
+	/// Modded tooltips often have requirements to hold keys like Shift or Ctrl in order
+	/// to see more information. With this flag enabled, all information provided
+	/// by this tooltip should be shown regardless of whether a key is held.
+	default boolean shouldDisplayAllInformation() {
+		return false;
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/TooltipTypeMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/TooltipTypeMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.item;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.item.tooltip.TooltipType;
+
+import net.fabricmc.fabric.api.item.v1.FabricTooltipType;
+
+@Mixin(TooltipType.class)
+public interface TooltipTypeMixin extends FabricTooltipType {
+}

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
@@ -18,7 +18,8 @@
     "LivingEntityMixin",
     "RecipeMixin",
     "RegistriesMixin",
-    "RegistryLoaderMixin"
+    "RegistryLoaderMixin",
+    "TooltipTypeMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric-item-api-v1/src/main/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/main/resources/fabric.mod.json
@@ -33,7 +33,8 @@
       "net/minecraft/class_1792": ["net/fabricmc/fabric/api/item/v1/FabricItem"],
       "net/minecraft/class_1792\u0024class_1793": ["net/fabricmc/fabric/api/item/v1/FabricItem\u0024Settings"],
       "net/minecraft/class_1799": ["net/fabricmc/fabric/api/item/v1/FabricItemStack"],
-      "net/minecraft/class_9323\u0024class_9324": ["net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder"]
+      "net/minecraft/class_9323\u0024class_9324": ["net/fabricmc/fabric/api/item/v1/FabricComponentMapBuilder"],
+      "net/minecraft/class_1836": ["net/fabricmc/fabric/api/item/v1/FabricTooltipType"]
     }
   }
 }


### PR DESCRIPTION
Backport of https://github.com/FabricMC/fabric-api/pull/5483 to 1.21.1, as requested by mezz.