### PR TITLE
Trigger chat message events for player-executed command messages (closes #5504)

### DIFF
--- a/fabric-message-api-v1/build.gradle
+++ b/fabric-message-api-v1/build.gradle
@@ -2,4 +2,7 @@ version = getSubprojectVersion(project)
 
 moduleDependencies(project, ['fabric-api-base'])
 
-testDependencies(project, ['fabric-command-api-v2'])
+testDependencies(project, [
+    'fabric-command-api-v2',
+    'fabric-events-interaction-v0'
+])

--- a/fabric-message-api-v1/build.gradle
+++ b/fabric-message-api-v1/build.gradle
@@ -3,6 +3,6 @@ version = getSubprojectVersion(project)
 moduleDependencies(project, ['fabric-api-base'])
 
 testDependencies(project, [
-    'fabric-command-api-v2',
-    'fabric-events-interaction-v0'
+	'fabric-command-api-v2',
+	'fabric-events-interaction-v0'
 ])

--- a/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/mixin/message/PlayerListMixin.java
+++ b/fabric-message-api-v1/src/main/java/net/fabricmc/fabric/mixin/message/PlayerListMixin.java
@@ -69,5 +69,20 @@ public abstract class PlayerListMixin {
 		}
 
 		ServerMessageEvents.COMMAND_MESSAGE.invoker().onCommandMessage(message, source, boundChatType);
+
+		// Vanilla used to delegate to the ServerPlayer overload when the source is a player,
+		// which triggered the chat events as documented. It no longer does, so trigger them here.
+		ServerPlayer sender = source.getPlayer();
+
+		if (sender == null) {
+			return;
+		}
+
+		if (!ServerMessageEvents.ALLOW_CHAT_MESSAGE.invoker().allowChatMessage(message, sender, boundChatType)) {
+			ci.cancel();
+			return;
+		}
+
+		ServerMessageEvents.CHAT_MESSAGE.invoker().onChatMessage(message, sender, boundChatType);
 	}
 }

--- a/fabric-message-api-v1/src/testmod/java/net/fabricmc/fabric/test/message/ChatGameTest.java
+++ b/fabric-message-api-v1/src/testmod/java/net/fabricmc/fabric/test/message/ChatGameTest.java
@@ -50,6 +50,7 @@ public class ChatGameTest {
 	 */
 	@GameTest
 	public void playerCommandMessageTriggersChatEvents(GameTestHelper helper) {
+		FIRED_EVENTS.clear();
 		ServerPlayer player = FakePlayer.get(helper.getLevel());
 		helper.getLevel().getServer().getCommands().performPrefixedCommand(player.createCommandSourceStack(), "/me " + MARKER);
 

--- a/fabric-message-api-v1/src/testmod/java/net/fabricmc/fabric/test/message/ChatGameTest.java
+++ b/fabric-message-api-v1/src/testmod/java/net/fabricmc/fabric/test/message/ChatGameTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.message;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import net.fabricmc.fabric.api.entity.FakePlayer;
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+import net.fabricmc.fabric.api.message.v1.ServerMessageEvents;
+
+public class ChatGameTest {
+	private static final String MARKER = "fabric message api gametest";
+	private static final List<String> FIRED_EVENTS = new CopyOnWriteArrayList<>();
+
+	static {
+		ServerMessageEvents.COMMAND_MESSAGE.register((message, source, params) -> {
+			if (message.signedContent().contains(MARKER)) FIRED_EVENTS.add("command");
+		});
+		ServerMessageEvents.ALLOW_CHAT_MESSAGE.register((message, sender, params) -> {
+			if (message.signedContent().contains(MARKER)) FIRED_EVENTS.add("allow_chat");
+			return true;
+		});
+		ServerMessageEvents.CHAT_MESSAGE.register((message, sender, params) -> {
+			if (message.signedContent().contains(MARKER)) FIRED_EVENTS.add("chat");
+		});
+	}
+
+	/**
+	 * A command message sent by a player must trigger the chat events after the
+	 * command events, as documented in {@link ServerMessageEvents}.
+	 */
+	@GameTest
+	public void playerCommandMessageTriggersChatEvents(GameTestHelper helper) {
+		ServerPlayer player = FakePlayer.get(helper.getLevel());
+		helper.getLevel().getServer().getCommands().performPrefixedCommand(player.createCommandSourceStack(), "/me " + MARKER);
+
+		helper.succeedWhen(() -> helper.assertTrue(
+				FIRED_EVENTS.equals(List.of("command", "allow_chat", "chat")),
+				Component.literal("Expected [command, allow_chat, chat] for a player-executed /me, got " + FIRED_EVENTS)
+		));
+	}
+}

--- a/fabric-message-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-message-api-v1/src/testmod/resources/fabric.mod.json
@@ -7,11 +7,15 @@
   "license": "Apache-2.0",
   "depends": {
     "fabric-message-api-v1": "*",
-    "fabric-command-api-v2": "*"
+    "fabric-command-api-v2": "*",
+    "fabric-events-interaction-v0": "*"
   },
   "entrypoints": {
     "main": [
       "net.fabricmc.fabric.test.message.ChatTest"
+    ],
+    "fabric-gametest": [
+      "net.fabricmc.fabric.test.message.ChatGameTest"
     ],
     "client": [
       "net.fabricmc.fabric.test.message.client.ChatTestClient"


### PR DESCRIPTION
Fixes #5504.

ServerMessageEvents documents that a command message broadcast by a player-executed command also triggers ALLOW_CHAT_MESSAGE and CHAT_MESSAGE after COMMAND_MESSAGE. This no longer happened because vanilla's PlayerList.broadcastChatMessage(PlayerChatMessage, CommandSourceStack, ChatType.Bound) used to delegate to the ServerPlayer overload (which Fabric hooks for the chat events) when the source was a player, but it now calls the private broadcast method directly, bypassing the hook.

This restores the documented behavior in PlayerListMixin: after COMMAND_MESSAGE, if the command source is a player, ALLOW_CHAT_MESSAGE is invoked (cancelling the broadcast when blocked) followed by CHAT_MESSAGE. Non-player sources (console, command blocks) are unchanged. No javadoc changes are needed since the documented behavior is restored.

### Testing

- New gametest (ChatGameTest): a FakePlayer executes /me and the test asserts COMMAND_MESSAGE, ALLOW_CHAT_MESSAGE and CHAT_MESSAGE are triggered in that order. Passes.
- Manual testing on the testmod dedicated server: console /me and /say trigger only the command events (no player source), and messages blocked by ALLOW_COMMAND_MESSAGE cancel the broadcast entirely.
- Tested in the dev environment (server side), not yet tested with a production fatjar build or a real client.