### PR TITLE
Add `AfterForeground` event

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
@@ -123,7 +123,7 @@ public final class ScreenEvents {
 	public static Event<BeforeExtract> beforeExtract(Screen screen) {
 		Objects.requireNonNull(screen, "Screen cannot be null");
 
-		return ScreenExtensions.getExtensions(screen).fabric_getBeforeRenderEvent();
+		return ScreenExtensions.getExtensions(screen).fabric_getBeforeExtractEvent();
 	}
 
 	/**
@@ -156,7 +156,7 @@ public final class ScreenEvents {
 	public static Event<AfterExtract> afterExtract(Screen screen) {
 		Objects.requireNonNull(screen, "Screen cannot be null");
 
-		return ScreenExtensions.getExtensions(screen).fabric_getAfterRenderEvent();
+		return ScreenExtensions.getExtensions(screen).fabric_getAfterExtractEvent();
 	}
 
 	/**

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenEvents.java
@@ -138,6 +138,17 @@ public final class ScreenEvents {
 	}
 
 	/**
+	 * An event that is called after a screen's foreground is extracted.
+	 *
+	 * @return the event
+	 */
+	public static Event<AfterForeground> afterForeground(Screen screen) {
+		Objects.requireNonNull(screen, "Screen cannot be null");
+
+		return ScreenExtensions.getExtensions(screen).fabric_getAfterForegroundEvent();
+	}
+
+	/**
 	 * An event that is called after a screen is extracted.
 	 *
 	 * @return the event
@@ -193,6 +204,11 @@ public final class ScreenEvents {
 	@FunctionalInterface
 	public interface AfterBackground {
 		void afterBackground(Screen screen, GuiGraphicsExtractor graphics, int mouseX, int mouseY, float tickProgress);
+	}
+
+	@FunctionalInterface
+	public interface AfterForeground {
+		void afterForeground(Screen screen, GuiGraphicsExtractor graphics, int mouseX, int mouseY, float tickProgress);
 	}
 
 	@FunctionalInterface

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
@@ -34,7 +34,7 @@ public final class ScreenEventFactory {
 		});
 	}
 
-	public static Event<ScreenEvents.BeforeExtract> createBeforeRenderEvent() {
+	public static Event<ScreenEvents.BeforeExtract> createBeforeExtractEvent() {
 		return EventFactory.createArrayBacked(ScreenEvents.BeforeExtract.class, callbacks -> (screen, matrices, mouseX, mouseY, tickDelta) -> {
 			for (ScreenEvents.BeforeExtract callback : callbacks) {
 				callback.beforeExtract(screen, matrices, mouseX, mouseY, tickDelta);
@@ -58,7 +58,7 @@ public final class ScreenEventFactory {
 		});
 	}
 
-	public static Event<ScreenEvents.AfterExtract> createAfterRenderEvent() {
+	public static Event<ScreenEvents.AfterExtract> createAfterExtractEvent() {
 		return EventFactory.createArrayBacked(ScreenEvents.AfterExtract.class, callbacks -> (screen, matrices, mouseX, mouseY, tickDelta) -> {
 			for (ScreenEvents.AfterExtract callback : callbacks) {
 				callback.afterExtract(screen, matrices, mouseX, mouseY, tickDelta);

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenEventFactory.java
@@ -50,6 +50,14 @@ public final class ScreenEventFactory {
 		});
 	}
 
+	public static Event<ScreenEvents.AfterForeground> createAfterForegroundEvent() {
+		return EventFactory.createArrayBacked(ScreenEvents.AfterForeground.class, callbacks -> (screen, matrices, mouseX, mouseY, tickDelta) -> {
+			for (ScreenEvents.AfterForeground callback : callbacks) {
+				callback.afterForeground(screen, matrices, mouseX, mouseY, tickDelta);
+			}
+		});
+	}
+
 	public static Event<ScreenEvents.AfterExtract> createAfterRenderEvent() {
 		return EventFactory.createArrayBacked(ScreenEvents.AfterExtract.class, callbacks -> (screen, matrices, mouseX, mouseY, tickDelta) -> {
 			for (ScreenEvents.AfterExtract callback : callbacks) {

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
@@ -39,13 +39,13 @@ public interface ScreenExtensions {
 
 	Event<ScreenEvents.AfterTick> fabric_getAfterTickEvent();
 
-	Event<ScreenEvents.BeforeExtract> fabric_getBeforeRenderEvent();
+	Event<ScreenEvents.BeforeExtract> fabric_getBeforeExtractEvent();
 
 	Event<ScreenEvents.AfterBackground> fabric_getAfterBackgroundEvent();
 
 	Event<ScreenEvents.AfterForeground> fabric_getAfterForegroundEvent();
 
-	Event<ScreenEvents.AfterExtract> fabric_getAfterRenderEvent();
+	Event<ScreenEvents.AfterExtract> fabric_getAfterExtractEvent();
 
 	// Keyboard
 

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/impl/client/screen/ScreenExtensions.java
@@ -43,6 +43,8 @@ public interface ScreenExtensions {
 
 	Event<ScreenEvents.AfterBackground> fabric_getAfterBackgroundEvent();
 
+	Event<ScreenEvents.AfterForeground> fabric_getAfterForegroundEvent();
+
 	Event<ScreenEvents.AfterExtract> fabric_getAfterRenderEvent();
 
 	// Keyboard

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/AbstractContainerScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/AbstractContainerScreenMixin.java
@@ -19,17 +19,27 @@ package net.fabricmc.fabric.mixin.screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
 
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
+
 @Mixin(AbstractContainerScreen.class)
 public abstract class AbstractContainerScreenMixin extends Screen {
 	private AbstractContainerScreenMixin(Component title) {
 		super(title);
+	}
+
+	@Inject(method = "extractRenderState", at = @At(value = "INVOKE",
+													target = "Lnet/minecraft/client/gui/screens/inventory/AbstractContainerScreen;extractContents(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIF)V", shift = At.Shift.AFTER))
+	public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a, CallbackInfo ci) {
+		ScreenEvents.afterForeground(this).invoker().afterForeground(this, graphics, mouseX, mouseY, a);
 	}
 
 	@Inject(method = "mouseReleased", at = @At("HEAD"), cancellable = true)

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/AbstractRecipeBookScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/AbstractRecipeBookScreenMixin.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.screen;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.screens.inventory.AbstractRecipeBookScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.RecipeBookMenu;
+
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
+
+@Mixin(AbstractRecipeBookScreen.class)
+abstract class AbstractRecipeBookScreenMixin<T extends RecipeBookMenu> extends AbstractContainerScreen<T> {
+	private AbstractRecipeBookScreenMixin(T menu, Inventory inventory, Component title) {
+		super(menu, inventory, title);
+	}
+
+	@Inject(method = "extractRenderState",
+			at = @At(value = "INVOKE",
+					target = "Lnet/minecraft/client/gui/screens/recipebook/RecipeBookComponent;extractRenderState(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIF)V",
+					shift = At.Shift.AFTER))
+	public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a, CallbackInfo ci) {
+		ScreenEvents.afterForeground((this))
+				.invoker()
+				.afterForeground(this, graphics, mouseX, mouseY, a);
+	}
+}

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -33,6 +33,7 @@ import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
@@ -66,6 +67,8 @@ abstract class ScreenMixin implements ScreenExtensions {
 	private Event<ScreenEvents.BeforeExtract> beforeRenderEvent;
 	@Unique
 	private Event<ScreenEvents.AfterBackground> afterBackgroundEvent;
+	@Unique
+	private Event<ScreenEvents.AfterForeground> afterForegroundEvent;
 	@Unique
 	private Event<ScreenEvents.AfterExtract> afterRenderEvent;
 
@@ -116,8 +119,15 @@ abstract class ScreenMixin implements ScreenExtensions {
 	private Event<ScreenMouseEvents.AfterMouseScroll> afterMouseScrollEvent;
 
 	@Inject(method = "extractRenderStateWithTooltipAndSubtitles", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;extractBackground(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIF)V", shift = At.Shift.AFTER))
-	public final void extractWithTooltip(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+	public final void extractBackground(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
 		ScreenEvents.afterBackground(((Screen) (Object) this)).invoker().afterBackground((Screen) (Object) this, graphics, mouseX, mouseY, deltaTicks);
+	}
+
+	@Inject(method = "extractRenderStateWithTooltipAndSubtitles", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;extractRenderState(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIF)V", shift = At.Shift.AFTER))
+	public final void extractForeground(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+		if (!(((Object) this) instanceof AbstractContainerScreen<?>)) {
+			ScreenEvents.afterForeground(((Screen) (Object) this)).invoker().afterForeground((Screen) (Object) this, graphics, mouseX, mouseY, deltaTicks);
+		}
 	}
 
 	@Inject(method = "init(II)V", at = @At("HEAD"))
@@ -147,6 +157,7 @@ abstract class ScreenMixin implements ScreenExtensions {
 		this.removeEvent = ScreenEventFactory.createRemoveEvent();
 		this.beforeRenderEvent = ScreenEventFactory.createBeforeRenderEvent();
 		this.afterBackgroundEvent = ScreenEventFactory.createAfterBackgroundEvent();
+		this.afterForegroundEvent = ScreenEventFactory.createAfterForegroundEvent();
 		this.afterRenderEvent = ScreenEventFactory.createAfterRenderEvent();
 		this.beforeTickEvent = ScreenEventFactory.createBeforeTickEvent();
 		this.afterTickEvent = ScreenEventFactory.createAfterTickEvent();
@@ -226,6 +237,11 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Override
 	public Event<ScreenEvents.AfterBackground> fabric_getAfterBackgroundEvent() {
 		return ensureEventsAreInitialized(this.afterBackgroundEvent);
+	}
+
+	@Override
+	public Event<ScreenEvents.AfterForeground> fabric_getAfterForegroundEvent() {
+		return ensureEventsAreInitialized(this.afterForegroundEvent);
 	}
 
 	@Override

--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/mixin/screen/ScreenMixin.java
@@ -64,13 +64,13 @@ abstract class ScreenMixin implements ScreenExtensions {
 	@Unique
 	private Event<ScreenEvents.AfterTick> afterTickEvent;
 	@Unique
-	private Event<ScreenEvents.BeforeExtract> beforeRenderEvent;
+	private Event<ScreenEvents.BeforeExtract> beforeExtractEvent;
 	@Unique
 	private Event<ScreenEvents.AfterBackground> afterBackgroundEvent;
 	@Unique
 	private Event<ScreenEvents.AfterForeground> afterForegroundEvent;
 	@Unique
-	private Event<ScreenEvents.AfterExtract> afterRenderEvent;
+	private Event<ScreenEvents.AfterExtract> afterExtractEvent;
 
 	// Keyboard
 	@Unique
@@ -155,10 +155,10 @@ abstract class ScreenMixin implements ScreenExtensions {
 		// All elements are repopulated on the screen, so we need to reinitialize all events
 		this.fabricButtons = null;
 		this.removeEvent = ScreenEventFactory.createRemoveEvent();
-		this.beforeRenderEvent = ScreenEventFactory.createBeforeRenderEvent();
+		this.beforeExtractEvent = ScreenEventFactory.createBeforeExtractEvent();
 		this.afterBackgroundEvent = ScreenEventFactory.createAfterBackgroundEvent();
 		this.afterForegroundEvent = ScreenEventFactory.createAfterForegroundEvent();
-		this.afterRenderEvent = ScreenEventFactory.createAfterRenderEvent();
+		this.afterExtractEvent = ScreenEventFactory.createAfterExtractEvent();
 		this.beforeTickEvent = ScreenEventFactory.createBeforeTickEvent();
 		this.afterTickEvent = ScreenEventFactory.createAfterTickEvent();
 
@@ -230,8 +230,8 @@ abstract class ScreenMixin implements ScreenExtensions {
 	}
 
 	@Override
-	public Event<ScreenEvents.BeforeExtract> fabric_getBeforeRenderEvent() {
-		return ensureEventsAreInitialized(this.beforeRenderEvent);
+	public Event<ScreenEvents.BeforeExtract> fabric_getBeforeExtractEvent() {
+		return ensureEventsAreInitialized(this.beforeExtractEvent);
 	}
 
 	@Override
@@ -245,8 +245,8 @@ abstract class ScreenMixin implements ScreenExtensions {
 	}
 
 	@Override
-	public Event<ScreenEvents.AfterExtract> fabric_getAfterRenderEvent() {
-		return ensureEventsAreInitialized(this.afterRenderEvent);
+	public Event<ScreenEvents.AfterExtract> fabric_getAfterExtractEvent() {
+		return ensureEventsAreInitialized(this.afterExtractEvent);
 	}
 
 	// Keyboard

--- a/fabric-screen-api-v1/src/client/resources/fabric-screen-api-v1.mixins.json
+++ b/fabric-screen-api-v1/src/client/resources/fabric-screen-api-v1.mixins.json
@@ -3,12 +3,13 @@
   "package": "net.fabricmc.fabric.mixin.screen",
   "compatibilityLevel": "JAVA_25",
   "mixins": [
+    "AbstractContainerScreenMixin",
+    "AbstractRecipeBookScreenMixin",
+    "GuiMixin",
     "KeyboardHandlerMixin",
+    "MinecraftMixin",
     "MouseHandlerMixin",
     "ScreenAccessor",
-    "GuiMixin",
-    "AbstractContainerScreenMixin",
-    "MinecraftMixin",
     "ScreenMixin"
   ],
   "injectors": {

--- a/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
+++ b/fabric-screen-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/screen/ScreenTests.java
@@ -78,16 +78,16 @@ public final class ScreenTests implements ClientModInitializer {
 					.findAny()
 					.orElseThrow(() -> new AssertionError("Failed to find the \"Stop Sound\" button in the screen's elements"));
 
-			ScreenKeyboardEvents.allowKeyPress(screen).register((_screen, event) -> {
+			ScreenKeyboardEvents.allowKeyPress(screen).register((_, event) -> {
 				LOGGER.info("Allow Key Press, Event: {}", event);
 				return true; // Let actions continue
 			});
 
-			ScreenKeyboardEvents.afterKeyPress(screen).register((_screen, event) -> {
+			ScreenKeyboardEvents.afterKeyPress(screen).register((_, event) -> {
 				LOGGER.warn("After Key Press, Event: {}", event);
 			});
 
-			ScreenKeyboardEvents.allowCharType(screen).register((_screen, event) -> {
+			ScreenKeyboardEvents.allowCharType(screen).register((_, event) -> {
 				LOGGER.warn("Allow Char Type, Event: {}, Character: {}", event, event.codepointAsString());
 				return true;
 			});
@@ -96,23 +96,30 @@ public final class ScreenTests implements ClientModInitializer {
 		} else if (screen instanceof GrindstoneScreen) {
 			// Register render event to draw an icon on the screen
 			// Expected result: the icon is drawn BEHIND both the container screen interface and the darkened background, text, items, the carried item, tooltips, etc.
-			ScreenEvents.beforeExtract(screen).register((_screen, graphics, mouseX, mouseY, tickDelta) -> {
+			ScreenEvents.beforeExtract(screen).register((_, graphics, mouseX, mouseY, tickDelta) -> {
 				// Render an armor icon to test
-				graphics.blitSprite(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) - 88 - 10, (screen.height / 2) - 34, 20, 20);
+				graphics.blitSprite(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) + 88 - 15, (screen.height / 2) - 34, 20, 20);
 			});
 
 			// Register render event to draw an icon on the screen
 			// Expected result: the icon is drawn ABOVE both the container screen interface and the darkened background, but still BEHIND text, items, the carried item, tooltips, etc.
-			ScreenEvents.afterBackground(screen).register((_screen, graphics, mouseX, mouseY, tickDelta) -> {
+			ScreenEvents.afterBackground(screen).register((_, graphics, mouseX, mouseY, tickDelta) -> {
 				// Render an armor icon to test
-				graphics.blitSprite(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) - 88 - 10, (screen.height / 2) - 10, 20, 20);
+				graphics.blitSprite(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) + 88 - 15, (screen.height / 2) - 10, 20, 20);
+			});
+
+			// Register render event to draw an icon on the screen
+			// Expected result: the icon is drawn ABOVE both the container screen interface and the darkened background, text, items, but still BEHIND the carried item, tooltips, etc.
+			ScreenEvents.afterForeground(screen).register((_, graphics, mouseX, mouseY, tickDelta) -> {
+				// Render an armor icon to test
+				graphics.blitSprite(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) + 88 - 15, (screen.height / 2) + 14, 20, 20);
 			});
 
 			// Register render event to draw an icon on the screen
 			// Expected result: the icon is drawn ABOVE everything, including the background, container screen interface, text, items, the carried item, tooltips, etc.
-			ScreenEvents.afterExtract(screen).register((_screen, graphics, mouseX, mouseY, tickDelta) -> {
+			ScreenEvents.afterExtract(screen).register((_, graphics, mouseX, mouseY, tickDelta) -> {
 				// Render an armor icon to test
-				graphics.blitSprite(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) - 88 - 10, (screen.height / 2) + 14, 20, 20);
+				graphics.blitSprite(RenderPipelines.GUI_TEXTURED, ScreenTests.ARMOR_FULL_TEXTURE, (screen.width / 2) + 88 - 15, (screen.height / 2) + 38, 20, 20);
 			});
 		}
 	}


### PR DESCRIPTION
There was an event missing when drawing screens that runs after text, items, slot highlight, etc., but before the carried item  tooltip and text tooltips.

Personally I need this to render custom item slot overlays in my [Easy Shulker Boxes](https://github.com/Fuzss/easy-shulker-boxes) mod, so there definitely is a valid use case.

The implementation mirrors [NeoForge](https://github.com/neoforged/NeoForge/pull/3342).

A simple test is implemented as well. The armor icon obstructing the hovered item is the one drawn via the new event.
<img width="1708" height="960" alt="2026-08-04_10 20 29" src="https://github.com/user-attachments/assets/b9b8a2da-acc0-492c-9891-0ac889f90595" />
