### PR TITLE
Add `ItemClickBehaviorCallback`

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ItemClickBehaviorCallback.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ItemClickBehaviorCallback.java
@@ -39,9 +39,9 @@ import net.fabricmc.fabric.api.util.EventResult;
 /// which is only ever handled client-side.
 @FunctionalInterface
 public interface ItemClickBehaviorCallback {
-	/// Callback that runs when
+	/// Callback that runs in
 	/// [net.minecraft.world.inventory.AbstractContainerMenu#tryItemClickBehaviourOverride(Player,
-	/// ClickAction, Slot, ItemStack, ItemStack)] is run.
+	/// ClickAction, Slot, ItemStack, ItemStack)].
 	Event<ItemClickBehaviorCallback> EVENT = EventFactory.createArrayBacked(
 			ItemClickBehaviorCallback.class,
 			callbacks -> (ItemStack hoveredItem, Slot hoveredSlot, ItemStack itemHeldByCursor, SlotAccess slotHeldByCursor, ClickAction clickAction, Player player) -> {

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ItemClickBehaviorCallback.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ItemClickBehaviorCallback.java
@@ -26,7 +26,7 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.api.util.EventResult;
 
-/// A single event which allows for overriding item behavior otherwise implemented via
+/// A single event that allows for overriding item behavior otherwise implemented via
 /// [ItemStack#overrideStackedOnOther(Slot, ClickAction, Player)] and
 /// [ItemStack#overrideOtherStackedOnMe(ItemStack, Slot, ClickAction, Player, SlotAccess)] on a
 /// per-item basis.
@@ -35,7 +35,7 @@ import net.fabricmc.fabric.api.util.EventResult;
 /// clicked and provides the item in the slot and the item currently carried by the cursor. Either
 /// item can be empty.
 ///
-/// This behavior runs on both the client & server side except the creative mode inventory menu,
+/// This behavior runs on both the client and server side except the creative mode inventory menu,
 /// which is only ever handled client-side.
 @FunctionalInterface
 public interface ItemClickBehaviorCallback {
@@ -69,10 +69,10 @@ public interface ItemClickBehaviorCallback {
 	/// @param clickAction      the mouse button that was used in the click
 	/// @param player           the player
 	/// @return [EventResult#ALLOW] to allow normal container menu click behavior to run,
-	///        [EventResult#DENY] to prevent normal click behavior, which allows for implementing a
+	/// 		[EventResult#DENY] to prevent normal click behavior, which allows for implementing a
 	/// 		custom interaction as vanilla does for bundles, [EventResult#PASS] to fall back to other
 	/// 		callbacks and eventually resolve [ItemStack#overrideStackedOnOther(Slot, ClickAction,
-	///        Player)] and [ItemStack#overrideOtherStackedOnMe(ItemStack, Slot, ClickAction, Player,
-	///        SlotAccess)]
+	/// 		Player)] and [ItemStack#overrideOtherStackedOnMe(ItemStack, Slot, ClickAction, Player,
+	/// 		SlotAccess)]
 	EventResult onItemClickBehavior(ItemStack hoveredItem, Slot hoveredSlot, ItemStack itemHeldByCursor, SlotAccess slotHeldByCursor, ClickAction clickAction, Player player);
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ItemClickBehaviorCallback.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ItemClickBehaviorCallback.java
@@ -26,14 +26,22 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.api.util.EventResult;
 
+/// A single event which allows for overriding item behavior otherwise implemented via
+/// [ItemStack#overrideStackedOnOther(Slot, ClickAction, Player)] and
+/// [ItemStack#overrideOtherStackedOnMe(ItemStack, Slot, ClickAction, Player, SlotAccess)] on a
+/// per-item basis.
+///
+/// The event runs whenever a slot in an [net.minecraft.world.inventory.AbstractContainerMenu] is
+/// clicked and provides the item in the slot and the item currently carried by the cursor. Either
+/// item can be empty.
+///
+/// This behavior runs on both the client & server side except the creative mode inventory menu,
+/// which is only ever handled client-side.
+@FunctionalInterface
 public interface ItemClickBehaviorCallback {
-	/// A single event which allows for overriding item behavior otherwise implemented via
-	/// [ItemStack#overrideStackedOnOther(Slot, ClickAction, Player)] and
-	/// [ItemStack#overrideOtherStackedOnMe(ItemStack, Slot, ClickAction, Player, SlotAccess)] on a
-	/// per-item basis.
-	///
-	/// The event runs whenever a slot in an [net.minecraft.world.inventory.AbstractContainerMenu]
-	/// is clicked and provides the item in the slot and the item currently carried by the cursor.
+	/// Callback that runs when
+	/// [net.minecraft.world.inventory.AbstractContainerMenu#tryItemClickBehaviourOverride(Player,
+	/// ClickAction, Slot, ItemStack, ItemStack)] is run.
 	Event<ItemClickBehaviorCallback> EVENT = EventFactory.createArrayBacked(
 			ItemClickBehaviorCallback.class,
 			callbacks -> (ItemStack hoveredItem, Slot hoveredSlot, ItemStack itemHeldByCursor, SlotAccess slotHeldByCursor, ClickAction clickAction, Player player) -> {
@@ -52,6 +60,8 @@ public interface ItemClickBehaviorCallback {
 				return EventResult.PASS;
 			});
 
+	/// Handles menu interactions when clicking items on top of each other in a container menu.
+	///
 	/// @param hoveredItem      the item in the slot hovered by the mouse cursor
 	/// @param hoveredSlot      the slot hovered by the mouse cursor
 	/// @param itemHeldByCursor the item carried by the cursor

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ItemClickBehaviorCallback.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/ItemClickBehaviorCallback.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.item.v1;
+
+import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.fabricmc.fabric.api.util.EventResult;
+
+public interface ItemClickBehaviorCallback {
+	/// A single event which allows for overriding item behavior otherwise implemented via
+	/// [ItemStack#overrideStackedOnOther(Slot, ClickAction, Player)] and
+	/// [ItemStack#overrideOtherStackedOnMe(ItemStack, Slot, ClickAction, Player, SlotAccess)] on a
+	/// per-item basis.
+	///
+	/// The event runs whenever a slot in an [net.minecraft.world.inventory.AbstractContainerMenu]
+	/// is clicked and provides the item in the slot and the item currently carried by the cursor.
+	Event<ItemClickBehaviorCallback> EVENT = EventFactory.createArrayBacked(
+			ItemClickBehaviorCallback.class,
+			callbacks -> (ItemStack hoveredItem, Slot hoveredSlot, ItemStack itemHeldByCursor, SlotAccess slotHeldByCursor, ClickAction clickAction, Player player) -> {
+				for (ItemClickBehaviorCallback callback : callbacks) {
+					EventResult result = callback.onItemClickBehavior(hoveredItem,
+							hoveredSlot,
+							itemHeldByCursor,
+							slotHeldByCursor,
+							clickAction,
+							player);
+					if (result != EventResult.PASS) {
+						return result;
+					}
+				}
+
+				return EventResult.PASS;
+			});
+
+	/// @param hoveredItem      the item in the slot hovered by the mouse cursor
+	/// @param hoveredSlot      the slot hovered by the mouse cursor
+	/// @param itemHeldByCursor the item carried by the cursor
+	/// @param slotHeldByCursor the slot abstraction for the cursor
+	/// @param clickAction      the mouse button that was used in the click
+	/// @param player           the player
+	/// @return [EventResult#ALLOW] to allow normal container menu click behavior to run,
+	///        [EventResult#DENY] to prevent normal click behavior, which allows for implementing a
+	/// 		custom interaction as vanilla does for bundles, [EventResult#PASS] to fall back to other
+	/// 		callbacks and eventually resolve [ItemStack#overrideStackedOnOther(Slot, ClickAction,
+	///        Player)] and [ItemStack#overrideOtherStackedOnMe(ItemStack, Slot, ClickAction, Player,
+	///        SlotAccess)]
+	EventResult onItemClickBehavior(ItemStack hoveredItem, Slot hoveredSlot, ItemStack itemHeldByCursor, SlotAccess slotHeldByCursor, ClickAction clickAction, Player player);
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/AbstractContainerMenuMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/AbstractContainerMenuMixin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.item;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+import net.fabricmc.fabric.api.item.v1.ItemClickBehaviorCallback;
+import net.fabricmc.fabric.api.util.EventResult;
+
+@Mixin(AbstractContainerMenu.class)
+abstract class AbstractContainerMenuMixin {
+	@Inject(method = "tryItemClickBehaviourOverride", at = @At("HEAD"), cancellable = true)
+	private void tryItemClickBehaviourOverride(Player player, ClickAction clickAction, Slot slot, ItemStack clicked, ItemStack carried, CallbackInfoReturnable<Boolean> callback) {
+		EventResult result = ItemClickBehaviorCallback.EVENT.invoker()
+				.onItemClickBehavior(clicked,
+						slot,
+						carried,
+						this.createCarriedSlotAccess(),
+						clickAction,
+						player);
+		if (result != EventResult.PASS) {
+			callback.setReturnValue(!result.allowAction());
+		}
+	}
+
+	@Shadow
+	private SlotAccess createCarriedSlotAccess() {
+		throw new RuntimeException();
+	}
+}

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/AbstractContainerMenuMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/AbstractContainerMenuMixin.java
@@ -35,7 +35,7 @@ import net.fabricmc.fabric.api.util.EventResult;
 @Mixin(AbstractContainerMenu.class)
 abstract class AbstractContainerMenuMixin {
 	@Inject(method = "tryItemClickBehaviourOverride", at = @At("HEAD"), cancellable = true)
-	private void tryItemClickBehaviourOverride(Player player, ClickAction clickAction, Slot slot, ItemStack clicked, ItemStack carried, CallbackInfoReturnable<Boolean> callback) {
+	private void overrideContainerMenuItemClickBehaviour(Player player, ClickAction clickAction, Slot slot, ItemStack clicked, ItemStack carried, CallbackInfoReturnable<Boolean> callback) {
 		EventResult result = ItemClickBehaviorCallback.EVENT.invoker()
 				.onItemClickBehavior(clicked,
 						slot,

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.item",
   "compatibilityLevel": "JAVA_25",
   "mixins": [
+    "AbstractContainerMenuMixin",
     "AbstractFurnaceBlockEntityMixin",
     "AnvilMenuMixin",
     "BrewingStandBlockEntityMixin",

--- a/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ItemClickBehaviorTest.java
+++ b/fabric-item-api-v1/src/testmod/java/net/fabricmc/fabric/test/item/ItemClickBehaviorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.test.item;
+
+import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.item.v1.ItemClickBehaviorCallback;
+import net.fabricmc.fabric.api.util.EventResult;
+
+public class ItemClickBehaviorTest implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		ItemClickBehaviorCallback.EVENT.register((ItemStack hoveredItem, Slot hoveredSlot, ItemStack itemHeldByCursor, SlotAccess slotHeldByCursor, ClickAction clickAction, Player player) -> {
+			if (hoveredItem.is(Items.DYED_BUNDLE.yellow())
+					|| itemHeldByCursor.is(Items.DYED_BUNDLE.yellow())) {
+				// Disables any special click behavior for yellow bundles, so they behave like most other items in container menus.
+				return EventResult.ALLOW;
+			} else if (hoveredItem.is(Items.COPPER_NUGGET) && !itemHeldByCursor.isEmpty()
+					|| !hoveredItem.isEmpty() && itemHeldByCursor.is(Items.COPPER_NUGGET)) {
+				// Prevents click interactions for copper nugget in container menus (without providing any special handling).
+				return EventResult.DENY;
+			} else {
+				return EventResult.PASS;
+			}
+		});
+	}
+}

--- a/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
+++ b/fabric-item-api-v1/src/testmod/resources/fabric.mod.json
@@ -10,13 +10,14 @@
   },
   "entrypoints": {
     "main": [
-      "net.fabricmc.fabric.test.item.CustomDamageTest",
-      "net.fabricmc.fabric.test.item.DefaultItemComponentTest",
-      "net.fabricmc.fabric.test.item.CustomModelIdTest",
-      "net.fabricmc.fabric.test.item.ItemUpdateAnimationTest",
-      "net.fabricmc.fabric.test.item.CustomEnchantmentEffectsTest",
       "net.fabricmc.fabric.test.item.ComponentTooltipProviderTest",
       "net.fabricmc.fabric.test.item.CreatorNamespaceTest",
+      "net.fabricmc.fabric.test.item.CustomDamageTest",
+      "net.fabricmc.fabric.test.item.CustomEnchantmentEffectsTest",
+      "net.fabricmc.fabric.test.item.CustomModelIdTest",
+      "net.fabricmc.fabric.test.item.DefaultItemComponentTest",
+      "net.fabricmc.fabric.test.item.ItemClickBehaviorTest",
+      "net.fabricmc.fabric.test.item.ItemUpdateAnimationTest",
       "net.fabricmc.fabric.test.item.ModifyComponentsInPropertiesTestSetup"
     ],
     "client": [


### PR DESCRIPTION
The new callback allows for controlling bundle-like container menu click behavior for all items.
Special behavior can be disabled (like from bundles) or added to any item by mods.

The implementation mirrors NeoForge's [ItemStackedOnOtherEvent](https://github.com/neoforged/NeoForge/blob/26.2.x/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java).

Personally I'm already using this behavior and injection point in my [Easy Shulker Boxes](https://modrinth.com/mod/easy-shulker-boxes) mod for adding bundle-like behavior to vanilla shulker boxes. Having an event like this in Fabric would greatly help with cross-mod compatibility.

I'm a bit unsure regarding the return value of the callback. I've chosen Fabric's own `EventResult`, but `TriState` could also be an option.
Also, the meaning of each return value is still up for debate. Right now I've chosen what feels most intuitive to me:
- `EventResult#ALLOW` forces the vanilla container menu click behavior to run (swapping or picking up items)
- `EventResult#DENY` prevents any of the default container menu click behavior for implementing custom behavior (as vanilla does for bundles)
- `EventResult#PASS` does nothing so the vanilla implementation can sort out whether to accept behavior overrides from the item or simply fall back to default click behavior