### PR TITLE
Allow supplying custom extension to FabricCodecDataProvider

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
@@ -80,7 +80,7 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	 * @param target the {@link PackOutput.Target} under which files will be written
 	 * @param directoryName the path under the target in which generated files will be written
 	 * @param codec the codec to use
-	 * @param extension the file extension to use for generated files, for example {@code mcmeta}. Must not start with a dot
+	 * @param extension the file extension without a {@code .} to use for generated files, for example {@code "mcmeta"}
 	 */
 	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, PackOutput.Target target, String directoryName, Codec<T> codec, String extension) {
 		this(packOutput.createPathProvider(target, directoryName), registriesFuture, codec, extension);
@@ -105,7 +105,7 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	 * @param registriesFuture the registry access
 	 * @param key the {@link ResourceKey} of the registry to generate for, used for determining where the generated files are written
 	 * @param codec the codec to use
-	 * @param extension the file extension to use for generated files, for example {@code mcmeta}. Must not start with a dot
+	 * @param extension the file extension without a {@code .} to use for generated files, for example {@code "mcmeta"}
 	 */
 	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, ResourceKey<? extends Registry<?>> key, Codec<T> codec, String extension) {
 		this(packOutput.createRegistryElementsPathProvider(key), registriesFuture, codec, extension);

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
@@ -59,18 +59,54 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 		this.extension = extension;
 	}
 
+	/**
+	 * Constructs a {@link FabricCodecDataProvider} for the provided codec, outputting generated files to the specified target and directory with the {@code json} file extension.
+	 *
+	 * @param packOutput the {@link FabricPackOutput} instance
+	 * @param registriesFuture the registry access
+	 * @param target the {@link PackOutput.Target} under which files will be written
+	 * @param directoryName the path under the target in which generated files will be written
+	 * @param codec the codec to use
+	 */
 	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, PackOutput.Target target, String directoryName, Codec<T> codec) {
 		this(packOutput.createPathProvider(target, directoryName), registriesFuture, codec, "json");
 	}
 
+	/**
+	 * Constructs a {@link FabricCodecDataProvider} for the provided codec, outputting generated files to the specified target and directory with the provided file extension.
+	 *
+	 * @param packOutput the {@link FabricPackOutput} instance
+	 * @param registriesFuture the registry access
+	 * @param target the {@link PackOutput.Target} under which files will be written
+	 * @param directoryName the path under the target in which generated files will be written
+	 * @param codec the codec to use
+	 * @param extension the file extension to use for generated files, for example {@code mcmeta}. Must not start with a dot
+	 */
 	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, PackOutput.Target target, String directoryName, Codec<T> codec, String extension) {
 		this(packOutput.createPathProvider(target, directoryName), registriesFuture, codec, extension);
 	}
 
+	/**
+	 * Constructs a {@link FabricCodecDataProvider} for the provided codec, outputting generated files to the path of the specified registry with the {@code json} file extension.
+	 *
+	 * @param packOutput the {@link FabricPackOutput} instance
+	 * @param registriesFuture the registry access
+	 * @param key the {@link ResourceKey} of the registry to generate for, used for determining where the generated files are written
+	 * @param codec the codec to use
+	 */
 	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, ResourceKey<? extends Registry<?>> key, Codec<T> codec) {
 		this(packOutput.createRegistryElementsPathProvider(key), registriesFuture, codec, "json");
 	}
 
+	/**
+	 * Constructs a {@link FabricCodecDataProvider} for the provided codec, outputting generated files to the path of the specified registry with the provided file extension.
+	 *
+	 * @param packOutput the {@link FabricPackOutput} instance
+	 * @param registriesFuture the registry access
+	 * @param key the {@link ResourceKey} of the registry to generate for, used for determining where the generated files are written
+	 * @param codec the codec to use
+	 * @param extension the file extension to use for generated files, for example {@code mcmeta}. Must not start with a dot
+	 */
 	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, ResourceKey<? extends Registry<?>> key, Codec<T> codec, String extension) {
 		this(packOutput.createRegistryElementsPathProvider(key), registriesFuture, codec, extension);
 	}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricCodecDataProvider.java
@@ -50,19 +50,29 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 	private final PackOutput.PathProvider pathProvider;
 	private final CompletableFuture<HolderLookup.Provider> registriesFuture;
 	private final Codec<T> codec;
+	private final String extension;
 
-	private FabricCodecDataProvider(PackOutput.PathProvider pathProvider, CompletableFuture<HolderLookup.Provider> registriesFuture, Codec<T> codec) {
+	private FabricCodecDataProvider(PackOutput.PathProvider pathProvider, CompletableFuture<HolderLookup.Provider> registriesFuture, Codec<T> codec, String extension) {
 		this.pathProvider = pathProvider;
 		this.registriesFuture = Objects.requireNonNull(registriesFuture);
 		this.codec = codec;
+		this.extension = extension;
 	}
 
 	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, PackOutput.Target target, String directoryName, Codec<T> codec) {
-		this(packOutput.createPathProvider(target, directoryName), registriesFuture, codec);
+		this(packOutput.createPathProvider(target, directoryName), registriesFuture, codec, "json");
+	}
+
+	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, PackOutput.Target target, String directoryName, Codec<T> codec, String extension) {
+		this(packOutput.createPathProvider(target, directoryName), registriesFuture, codec, extension);
 	}
 
 	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, ResourceKey<? extends Registry<?>> key, Codec<T> codec) {
-		this(packOutput.createRegistryElementsPathProvider(key), registriesFuture, codec);
+		this(packOutput.createRegistryElementsPathProvider(key), registriesFuture, codec, "json");
+	}
+
+	protected FabricCodecDataProvider(FabricPackOutput packOutput, CompletableFuture<HolderLookup.Provider> registriesFuture, ResourceKey<? extends Registry<?>> key, Codec<T> codec, String extension) {
+		this(packOutput.createRegistryElementsPathProvider(key), registriesFuture, codec, extension);
 	}
 
 	@Override
@@ -101,7 +111,7 @@ public abstract class FabricCodecDataProvider<T> implements DataProvider {
 
 	private CompletableFuture<?> write(CachedOutput output, Map<Identifier, JsonElement> entries) {
 		return CompletableFuture.allOf(entries.entrySet().stream().map(entry -> {
-			Path path = this.pathProvider.json(entry.getKey());
+			Path path = this.pathProvider.file(entry.getKey(), extension);
 			return DataProvider.saveStable(output, entry.getValue(), path);
 		}).toArray(CompletableFuture[]::new));
 	}

--- a/fabric-data-generation-api-v1/src/testmod/generated/resourcepacks/example_builtin/assets/fabric-data-gen-api-v1-testmod/textures/block/animation_metadata_example.mcmeta
+++ b/fabric-data-generation-api-v1/src/testmod/generated/resourcepacks/example_builtin/assets/fabric-data-gen-api-v1-testmod/textures/block/animation_metadata_example.mcmeta
@@ -1,0 +1,16 @@
+{
+  "animation": {
+    "frames": [
+      1,
+      {
+        "index": 2,
+        "time": 20
+      },
+      3
+    ],
+    "frametime": 10,
+    "height": 16,
+    "interpolate": true,
+    "width": 16
+  }
+}

--- a/fabric-data-generation-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/datagen/client/DataGeneratorClientTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/datagen/client/DataGeneratorClientTestEntrypoint.java
@@ -19,14 +19,19 @@ package net.fabricmc.fabric.test.datagen.client;
 import static net.fabricmc.fabric.test.datagen.DataGeneratorTestContent.MOD_ID;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
+
+import com.mojang.serialization.Codec;
 
 import net.minecraft.client.data.models.BlockModelGenerators;
 import net.minecraft.client.data.models.ItemModelGenerators;
 import net.minecraft.client.renderer.texture.atlas.SpriteSource;
 import net.minecraft.client.renderer.texture.atlas.SpriteSources;
 import net.minecraft.client.renderer.texture.atlas.sources.DirectoryLister;
+import net.minecraft.client.resources.metadata.animation.AnimationFrame;
+import net.minecraft.client.resources.metadata.animation.AnimationMetadataSection;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.HolderLookup.Provider;
 import net.minecraft.data.PackOutput;
@@ -53,6 +58,7 @@ public class DataGeneratorClientTestEntrypoint implements DataGeneratorEntrypoin
 	public void onInitializeDataGenerator(FabricDataGenerator dataGenerator) {
 		final FabricDataGenerator.Pack pack = dataGenerator.createBuiltinResourcePack(Identifier.fromNamespaceAndPath(MOD_ID, "example_builtin"));
 		pack.addProvider(TestAtlasSourceProvider::new);
+		pack.addProvider(TestAnimationMetadataProvider::new);
 		pack.addProvider(TestModelProvider::new);
 		pack.addProvider(TestSoundsProvider::new);
 	}
@@ -70,6 +76,34 @@ public class DataGeneratorClientTestEntrypoint implements DataGeneratorEntrypoin
 		@Override
 		public String getName() {
 			return "Atlas Sources";
+		}
+	}
+
+	private static class TestAnimationMetadataProvider extends FabricCodecDataProvider<AnimationMetadataSection> {
+		private static final Codec<AnimationMetadataSection> CODEC = AnimationMetadataSection.CODEC.fieldOf("animation").codec();
+
+		protected TestAnimationMetadataProvider(FabricPackOutput packOutput, CompletableFuture<Provider> registriesFuture) {
+			super(packOutput, registriesFuture, PackOutput.Target.RESOURCE_PACK, "textures", CODEC, "mcmeta");
+		}
+
+		@Override
+		protected void configure(BiConsumer<Identifier, AnimationMetadataSection> provider, Provider registryLookup) {
+			provider.accept(Identifier.fromNamespaceAndPath(MOD_ID, "block/animation_metadata_example"), new AnimationMetadataSection(
+					Optional.of(List.of(
+							new AnimationFrame(1),
+							new AnimationFrame(2, Optional.of(20)),
+							new AnimationFrame(3)
+					)),
+					Optional.of(16),
+					Optional.of(16),
+					10,
+					true
+			));
+		}
+
+		@Override
+		public String getName() {
+			return "Animation Metadata";
 		}
 	}
 


### PR DESCRIPTION
Adds an `extension` field to `FabricCodecDataProvider` for specifying the generated file's extension, which may not always be `json`. Constructors with existing signature default to json.

Added a data generator to the testmod that generates an animation metadata file, which uses the `mcmeta` extension.

Would be great if this got added to 26.1 as well, shouldn't require any changes for backporting there