### PR TITLE
Fix incorrect Javadoc on beforeKeyRelease event

### DIFF
--- a/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenKeyboardEvents.java
+++ b/fabric-screen-api-v1/src/client/java/net/fabricmc/fabric/api/client/screen/v1/ScreenKeyboardEvents.java
@@ -84,7 +84,7 @@ public final class ScreenKeyboardEvents {
 	}
 
 	/**
-	 * An event that is called after the release of a key is processed for a screen.
+	 * An event that is called before the release of a key is processed for a screen.
 	 *
 	 * @return the event
 	 */


### PR DESCRIPTION
Fixes #5532

`ScreenKeyboardEvents#beforeKeyRelease` was documented as firing "after the release of a key is processed", which contradicts both its name and the `BeforeKeyRelease` functional interface's own Javadoc ("Called before a pressed key has been released"). Likely a copy paste from the adjacent `afterKeyRelease` event, which correctly uses "after".

Javadoc only change, one word.