### PR TITLE
[26.2+] Fix wrong injection for capturing entity spawn reason

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/EntityTypeMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/EntityTypeMixin.java
@@ -22,7 +22,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.EntitySpawnRequest;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
 
@@ -31,14 +31,14 @@ import net.fabricmc.fabric.impl.event.lifecycle.EntityLoadDataSetter;
 @Mixin(EntityType.class)
 public class EntityTypeMixin {
 	@Inject(
-			method = "create(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/EntitySpawnReason;)Lnet/minecraft/world/entity/Entity;",
+			method = "create(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/EntitySpawnRequest;)Lnet/minecraft/world/entity/Entity;",
 			at = @At("RETURN")
 	)
-	private <T extends Entity> void setSpawnReason(Level level, EntitySpawnReason reason, CallbackInfoReturnable<T> cir) {
+	private <T extends Entity> void setSpawnReason(Level level, EntitySpawnRequest request, CallbackInfoReturnable<T> cir) {
 		T entity = cir.getReturnValue();
 
 		if (entity != null) {
-			((EntityLoadDataSetter) entity).fabric_setSpawnReason(reason);
+			((EntityLoadDataSetter) entity).fabric_setSpawnReason(request.reason());
 		}
 	}
 }


### PR DESCRIPTION
In 26.2 vanilla added a new method for creating an `Entity` from an `EntityType`:
```java
Entity create(Level, EntitySpawnRequest)
```

The method previously used for creating the actual entity (`Entity create(Level, EntitySpawnReason)`) still exists, but now serves as an overload for the new method.

This moves the injection for capturing the spawn reason to the new base method.
This is relevant for cases where vanilla calls the `EntitySpawnRequest` based method directly e.g., when spawning entities during world generation.