### PR TITLE
Don't run client gametest mod initializer if disabled

### DIFF
--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/FabricClientGameTestImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/FabricClientGameTestImpl.java
@@ -30,6 +30,10 @@ public class FabricClientGameTestImpl implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
+		if (!TestSystemProperties.ENABLED) {
+			return;
+		}
+
 		ThreadingImpl.unsafeClientInstance = Minecraft.getInstance();
 
 		PayloadTypeRegistry.serverboundPlay().register(GameTestSyncPayload.TYPE, GameTestSyncPayload.CODEC);


### PR DESCRIPTION
Can be backported to 26.2 as well