### PR TITLE
Fix dependency cycle in ConventionalBlockItemTags

### DIFF
--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalBlockItemTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalBlockItemTags.java
@@ -26,6 +26,8 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.ColorCollection;
 
+import net.fabricmc.fabric.impl.tag.convention.v2.TagRegistration;
+
 /**
  * See {@link net.minecraft.tags.BlockItemTags} for vanilla tags.
  * Note that addition to some vanilla tags implies having certain functionality.
@@ -338,7 +340,7 @@ public final class ConventionalBlockItemTags {
 	/**
 	 * Tag that holds all head based blocks such as Skeleton Skull or Player Head. (Named skulls to match minecraft:skulls item tag)
 	 */
-	public static final BlockItemTagId SKULLS = register(ConventionalBlockTags.SKULLS, ItemTags.SKULLS);
+	public static final BlockItemTagId SKULLS = register(TagRegistration.BLOCK_TAG.registerC("skulls"), ItemTags.SKULLS);
 	public static final BlockItemTagId ROPES = register("ropes");
 	public static final BlockItemTagId CHAINS = register("chains");
 

--- a/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalBlockTags.java
+++ b/fabric-convention-tags-v2/src/main/java/net/fabricmc/fabric/api/tag/convention/v2/ConventionalBlockTags.java
@@ -344,7 +344,7 @@ public final class ConventionalBlockTags {
 	/**
 	 * Tag that holds all head based blocks such as Skeleton Skull or Player Head. (Named skulls to match minecraft:skulls item tag)
 	 */
-	public static final TagKey<Block> SKULLS = register("skulls");
+	public static final TagKey<Block> SKULLS = ConventionalBlockItemTags.SKULLS.block();
 	public static final TagKey<Block> ROPES = ConventionalBlockItemTags.ROPES.block();
 	public static final TagKey<Block> CHAINS = ConventionalBlockItemTags.CHAINS.block();
 


### PR DESCRIPTION
`ConventionalBlockItemTags` contains the line `BlockItemTagId SKULLS = register(ConventionalBlockTags.SKULLS, ItemTags.SKULLS)`, which then tries to load `ConventionalBlockTags`. But its constructor tries to read fields defined in the block item tags class, which is partially initialised, and so you get an NPE.

This moves the tag creation into `ConventionalBlockItemTags`, removing the dependency cycle.