### PR TITLE
Allow mods to define reloadable registries in DataGeneratorEntrypoint

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/DataGeneratorEntrypoint.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.api.datagen.v1;
 import org.jspecify.annotations.Nullable;
 
 import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.core.registries.SingleRegistryBootstrap;
 import net.minecraft.resources.ResourceKey;
 
 /**
@@ -50,8 +51,8 @@ public interface DataGeneratorEntrypoint {
 	}
 
 	/**
-	 * Builds a registry containing dynamic registry entries to be generated.
-	 * Users should call {@link RegistrySetBuilder#add(ResourceKey, RegistrySetBuilder.RegistryBootstrap)}
+	 * Builds a registry containing world dynamic registry entries to be generated.
+	 * Users should call {@link RegistrySetBuilder#add(ResourceKey, SingleRegistryBootstrap)}
 	 * to register a bootstrap function, which adds registry entries to be generated.
 	 *
 	 * <p>This is invoked asynchronously.
@@ -59,6 +60,18 @@ public interface DataGeneratorEntrypoint {
 	 * @param registryBuilder a {@link RegistrySetBuilder} instance
 	 */
 	default void buildRegistry(RegistrySetBuilder registryBuilder) {
+	}
+
+	/**
+	 * Builds a registry containing reloadable dynamic registry entries to be generated.
+	 * Users should call {@link RegistrySetBuilder#add(ResourceKey, SingleRegistryBootstrap)}
+	 * to register a bootstrap function, which adds registry entries to be generated.
+	 *
+	 * <p>This is invoked asynchronously.
+	 *
+	 * @param registryBuilder a {@link RegistrySetBuilder} instance
+	 */
+	default void buildReloadableRegistry(RegistrySetBuilder registryBuilder) {
 	}
 
 	/**

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 
 import com.google.gson.JsonObject;
 import com.mojang.logging.LogUtils;
@@ -119,7 +118,7 @@ public final class FabricDataGenHelper {
 		// Ensure that the DataGeneratorEntrypoint is constructed on the main thread.
 		final List<DataGeneratorEntrypoint> entrypoints = dataGeneratorInitializers.stream().map(EntrypointContainer::getEntrypoint).toList();
 		CompletableFuture<HolderLookup.Provider> worldRegistriesFuture = CompletableFuture.supplyAsync(() -> createWorldLookupProvider(entrypoints), Util.backgroundExecutor());
-		CompletableFuture<HolderLookup.Provider> registriesFuture = worldRegistriesFuture.thenComposeAsync(FabricDataGenHelper::createReloadableLookupProvider, Util.backgroundExecutor());
+		CompletableFuture<HolderLookup.Provider> registriesFuture = worldRegistriesFuture.thenComposeAsync(provider -> createReloadableLookupProvider(entrypoints, provider), Util.backgroundExecutor());
 
 		Object2IntOpenHashMap<String> jsonKeySortOrders = (Object2IntOpenHashMap<String>) DataProvider.FIXED_ORDER_FIELDS;
 		Object2IntOpenHashMap<String> defaultJsonKeySortOrders = new Object2IntOpenHashMap<>(jsonKeySortOrders);
@@ -188,7 +187,7 @@ public final class FabricDataGenHelper {
 		return registryLookup;
 	}
 
-	private static CompletableFuture<HolderLookup.Provider> createReloadableLookupProvider(HolderLookup.Provider registryLookup) {
+	private static CompletableFuture<HolderLookup.Provider> createReloadableLookupProvider(List<DataGeneratorEntrypoint> dataGeneratorInitializers, HolderLookup.Provider registryLookup) {
 		PackRepository packRepository = ServerPacksSource.createVanillaTrustedRepository();
 		packRepository.reload();
 		packRepository.setSelected(List.of(BuiltInPackSource.VANILLA_ID));
@@ -213,17 +212,23 @@ public final class FabricDataGenHelper {
 			}
 		}
 
-		HolderLookup.Provider reloadableRegistryLookup = reloadableRegistryBuilder.build(registryLookup);
+		for (DataGeneratorEntrypoint entrypoint : dataGeneratorInitializers) {
+			entrypoint.buildReloadableRegistry(reloadableRegistryBuilder);
+		}
 
-		return reloadableRegistriesFuture.thenApply(reloadableRegistries -> HolderLookup.Provider.create(
-				Stream.concat(
-						registryLookup.listRegistries(),
-						Stream.concat(
-								reloadableRegistryLookup.listRegistries().filter(lookup -> moddedReloadableRegistries.contains(lookup.key())),
-								reloadableRegistries.listRegistries()
-						)
-				)
-		)).whenComplete((_, _) -> resourceManager.close());
+		return reloadableRegistriesFuture.thenApply(reloadableRegistries -> {
+			reloadableRegistries.listRegistries().forEach(registry -> {
+				//noinspection unchecked
+				reloadableRegistryBuilder.add((ResourceKey<Registry<Object>>) registry.key(), bootstrap -> {
+					//noinspection unchecked
+					((HolderLookup.RegistryLookup<Object>) registry).listElements().forEach(reference -> {
+						bootstrap.register(reference.key(), reference.value());
+					});
+				});
+			});
+
+			return reloadableRegistryBuilder.build(registryLookup);
+		}).whenComplete((_, _) -> resourceManager.close());
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/impl/datagen/FabricDataGenHelper.java
@@ -44,12 +44,6 @@ import net.minecraft.data.DataProvider;
 import net.minecraft.data.registries.VanillaRegistries;
 import net.minecraft.resources.RegistryDataLoader;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.repository.BuiltInPackSource;
-import net.minecraft.server.packs.repository.PackRepository;
-import net.minecraft.server.packs.repository.ServerPacksSource;
-import net.minecraft.server.packs.resources.CloseableResourceManager;
-import net.minecraft.server.packs.resources.MultiPackResourceManager;
 import net.minecraft.util.Util;
 
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
@@ -118,7 +112,7 @@ public final class FabricDataGenHelper {
 		// Ensure that the DataGeneratorEntrypoint is constructed on the main thread.
 		final List<DataGeneratorEntrypoint> entrypoints = dataGeneratorInitializers.stream().map(EntrypointContainer::getEntrypoint).toList();
 		CompletableFuture<HolderLookup.Provider> worldRegistriesFuture = CompletableFuture.supplyAsync(() -> createWorldLookupProvider(entrypoints), Util.backgroundExecutor());
-		CompletableFuture<HolderLookup.Provider> registriesFuture = worldRegistriesFuture.thenComposeAsync(provider -> createReloadableLookupProvider(entrypoints, provider), Util.backgroundExecutor());
+		CompletableFuture<HolderLookup.Provider> registriesFuture = worldRegistriesFuture.thenApplyAsync(provider -> createReloadableLookupProvider(entrypoints, provider), Util.backgroundExecutor());
 
 		Object2IntOpenHashMap<String> jsonKeySortOrders = (Object2IntOpenHashMap<String>) DataProvider.FIXED_ORDER_FIELDS;
 		Object2IntOpenHashMap<String> defaultJsonKeySortOrders = new Object2IntOpenHashMap<>(jsonKeySortOrders);
@@ -187,48 +181,26 @@ public final class FabricDataGenHelper {
 		return registryLookup;
 	}
 
-	private static CompletableFuture<HolderLookup.Provider> createReloadableLookupProvider(List<DataGeneratorEntrypoint> dataGeneratorInitializers, HolderLookup.Provider registryLookup) {
-		PackRepository packRepository = ServerPacksSource.createVanillaTrustedRepository();
-		packRepository.reload();
-		packRepository.setSelected(List.of(BuiltInPackSource.VANILLA_ID));
-
-		CloseableResourceManager resourceManager = new MultiPackResourceManager(PackType.SERVER_DATA, packRepository.openAllSelected());
-		CompletableFuture<RegistryAccess.Frozen> reloadableRegistriesFuture = RegistryDataLoader.load(
-				resourceManager,
-				registryLookup.listRegistries().toList(),
-				RegistryDataLoader.RELOADABLE_REGISTRIES,
-				Util.backgroundExecutor()
-		);
-
-		RegistrySetBuilder reloadableRegistryBuilder = new RegistrySetBuilder();
+	private static HolderLookup.Provider createReloadableLookupProvider(List<DataGeneratorEntrypoint> dataGeneratorInitializers, HolderLookup.Provider registryLookup) {
+		RegistrySetBuilder registryBuilder = new RegistrySetBuilder();
 		HashSet<ResourceKey<? extends Registry<?>>> vanillaReloadableRegistries = new HashSet<>();
-		HashSet<ResourceKey<? extends Registry<?>>> moddedReloadableRegistries = new HashSet<>();
-		RegistryDataLoader.RELOADABLE_REGISTRIES.forEach(registry -> vanillaReloadableRegistries.add(registry.key()));
+		VanillaRegistries.RELOADABLE_BUILDER.entries.stream()
+				.flatMap(RegistrySetBuilder.RegistryStub::requiredRegistries)
+				.forEach(vanillaReloadableRegistries::add);
 
 		for (RegistryDataLoader.RegistryData<?> registry : DynamicRegistries.getReloadableRegistries()) {
 			if (!vanillaReloadableRegistries.contains(registry.key())) {
-				addEmptyRegistry(reloadableRegistryBuilder, registry.key());
-				moddedReloadableRegistries.add(registry.key());
+				addEmptyRegistry(registryBuilder, registry.key());
 			}
 		}
 
+		registryBuilder.entries.addAll(VanillaRegistries.RELOADABLE_BUILDER.entries);
+
 		for (DataGeneratorEntrypoint entrypoint : dataGeneratorInitializers) {
-			entrypoint.buildReloadableRegistry(reloadableRegistryBuilder);
+			entrypoint.buildReloadableRegistry(registryBuilder);
 		}
 
-		return reloadableRegistriesFuture.thenApply(reloadableRegistries -> {
-			reloadableRegistries.listRegistries().forEach(registry -> {
-				//noinspection unchecked
-				reloadableRegistryBuilder.add((ResourceKey<Registry<Object>>) registry.key(), bootstrap -> {
-					//noinspection unchecked
-					((HolderLookup.RegistryLookup<Object>) registry).listElements().forEach(reference -> {
-						bootstrap.register(reference.key(), reference.value());
-					});
-				});
-			});
-
-			return reloadableRegistryBuilder.build(registryLookup);
-		}).whenComplete((_, _) -> resourceManager.close());
+		return registryBuilder.build(registryLookup);
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/loot/BlockLootSubProviderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/loot/BlockLootSubProviderMixin.java
@@ -16,12 +16,29 @@
 
 package net.fabricmc.fabric.mixin.datagen.loot;
 
-import org.spongepowered.asm.mixin.Mixin;
+import java.util.Iterator;
 
+import com.google.common.collect.Iterators;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.loot.BlockLootSubProvider;
+import net.minecraft.data.loot.packs.VanillaBlockLoot;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.block.Block;
 
 import net.fabricmc.fabric.api.datagen.v1.loot.FabricBlockLootSubProvider;
 
 @Mixin(BlockLootSubProvider.class)
 public class BlockLootSubProviderMixin implements FabricBlockLootSubProvider {
+	@ModifyExpressionValue(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/DefaultedRegistry;iterator()Ljava/util/Iterator;"))
+	private Iterator<Block> onlyVanillaBlocks(Iterator<Block> blocks) {
+		if ((Object) this instanceof VanillaBlockLoot) {
+			return Iterators.filter(blocks, block -> BuiltInRegistries.BLOCK.getKey(block).getNamespace().equals(Identifier.DEFAULT_NAMESPACE));
+		}
+
+		return blocks;
+	}
 }

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/loot/EntityLootSubProviderMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/loot/EntityLootSubProviderMixin.java
@@ -16,12 +16,28 @@
 
 package net.fabricmc.fabric.mixin.datagen.loot;
 
-import org.spongepowered.asm.mixin.Mixin;
+import java.util.stream.Stream;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.core.Holder;
 import net.minecraft.data.loot.EntityLootSubProvider;
+import net.minecraft.data.loot.packs.VanillaEntityLoot;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.EntityType;
 
 import net.fabricmc.fabric.api.datagen.v1.loot.FabricEntityLootSubProvider;
 
 @Mixin(EntityLootSubProvider.class)
 public class EntityLootSubProviderMixin implements FabricEntityLootSubProvider {
+	@ModifyExpressionValue(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/data/loot/LootTableSubProvider$Context;listContextElements(Lnet/minecraft/resources/ResourceKey;)Ljava/util/stream/Stream;"))
+	private Stream<Holder.Reference<EntityType<?>>> onlyVanillaEntities(Stream<Holder.Reference<EntityType<?>>> entities) {
+		if ((Object) this instanceof VanillaEntityLoot) {
+			return entities.filter(entity -> entity.key().identifier().getNamespace().equals(Identifier.DEFAULT_NAMESPACE));
+		}
+
+		return entities;
+	}
 }

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.classtweaker
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.classtweaker
@@ -26,6 +26,7 @@ extendable	method	net/minecraft/data/DataGenerator$PackGenerator	<init>	(Lnet/mi
 
 accessible	method	net/minecraft/data/registries/VanillaRegistries	validateThatAllBiomeFeaturesHaveBiomeFilter	(Lnet/minecraft/core/HolderLookup$Provider;)V
 accessible	field	net/minecraft/data/registries/VanillaRegistries	WORLD_BUILDER	Lnet/minecraft/core/RegistrySetBuilder;
+accessible	field	net/minecraft/data/registries/VanillaRegistries	RELOADABLE_BUILDER	Lnet/minecraft/core/RegistrySetBuilder;
 accessible	field	net/minecraft/core/RegistrySetBuilder	entries	Ljava/util/List;
 accessible	class	net/minecraft/core/RegistrySetBuilder$RegistryStub
 accessible	method	net/minecraft/core/RegistrySetBuilder$RegistryStub	requiredRegistries	()Ljava/util/stream/Stream;

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/test/recipe_depentent.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/advancement/test/recipe_depentent.json
@@ -1,0 +1,27 @@
+{
+  "parent": "fabric-data-gen-api-v1-testmod:test/root",
+  "criteria": {
+    "recipe_unlocked": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipes": "fabric-data-gen-api-v1-testmod:test/potato_duplication"
+      }
+    }
+  },
+  "display": {
+    "announce_to_chat": false,
+    "description": "You unlocked the Potato Duplication recipe.",
+    "frame": "goal",
+    "icon": {
+      "id": "minecraft:potato"
+    },
+    "show_toast": false,
+    "title": "Potato Duplication Recipe Dependent"
+  },
+  "requirements": [
+    [
+      "recipe_unlocked"
+    ]
+  ],
+  "sends_telemetry_event": true
+}

--- a/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/recipe/test/potato_duplication.json
+++ b/fabric-data-generation-api-v1/src/testmod/generated/data/fabric-data-gen-api-v1-testmod/recipe/test/potato_duplication.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "equipment",
+  "ingredients": [
+    "minecraft:dirt",
+    "minecraft:potato"
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:potato"
+  }
+}

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -46,14 +47,18 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementType;
+import net.minecraft.advancements.triggers.InventoryChangeTrigger;
 import net.minecraft.advancements.triggers.KilledTrigger;
+import net.minecraft.advancements.triggers.RecipeUnlockedTrigger;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderGetter;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry;
 import net.minecraft.core.RegistrySetBuilder;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.MultiRegistryBootstrap;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.core.registries.codec.RegistryCodecs;
 import net.minecraft.data.PackOutput;
@@ -115,6 +120,8 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 	private static final ResourceCondition ALWAYS_LOADED = ResourceConditions.alwaysTrue();
 	private static final ResourceCondition NEVER_LOADED = ResourceConditions.alwaysFalse();
 
+	private static final ResourceKey<Recipe<?>> POTATO_DUPLICATION_RECIPE = ResourceKey.create(Registries.RECIPE, Identifier.fromNamespaceAndPath("fabric-data-gen-api-v1-testmod", "test/potato_duplication"));
+
 	@Override
 	public void addJsonKeySortOrders(JsonKeySortOrderCallback callback) {
 		callback.add("trigger", 0);
@@ -171,6 +178,21 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 				this::bootstrapTestDatagenRegistry
 		);
 		// do NOT add TEST_DATAGEN_DYNAMIC_EMPTY_REGISTRY_KEY, should still work without it
+	}
+
+	@Override
+	public void buildReloadableRegistry(RegistrySetBuilder registryBuilder) {
+		registryBuilder.add(new MultiRegistryBootstrap() {
+			@Override
+			public Set<ResourceKey<? extends Registry<?>>> requestedRegistries() {
+				return Set.of(Registries.ADVANCEMENT, Registries.RECIPE);
+			}
+
+			@Override
+			public void run(BootstrapGetter registries) {
+				createReloadableRecipeProvider(registries.get(Registries.RECIPE), registries.get(Registries.ADVANCEMENT)).buildRecipes();
+			}
+		});
 	}
 
 	private void bootstrapTestDatagenRegistry(BootstrapContext<DataGeneratorTestContent.TestDatagenObject> context) {
@@ -285,6 +307,19 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		public String getName() {
 			return "Test Recipes";
 		}
+	}
+
+	private static RecipeProvider createReloadableRecipeProvider(BootstrapContext<Recipe<?>> recipes, BootstrapContext<Advancement> advancements) {
+		return new RecipeProvider(recipes, advancements) {
+			@Override
+			public void buildRecipes() {
+				shapeless(RecipeCategory.TOOLS, Items.POTATO, 4)
+						.requires(Items.DIRT)
+						.requires(Items.POTATO)
+						.unlockedBy("potato", InventoryChangeTrigger.TriggerInstance.hasItems(Items.POTATO))
+						.save(output, POTATO_DUPLICATION_RECIPE);
+			}
+		};
 	}
 
 	private static class ExistingEnglishLangProvider extends FabricLanguageProvider {
@@ -441,6 +476,17 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 					.addCriterion("killed_something", KilledTrigger.TriggerInstance.playerKilledEntity())
 					.parent(createPlaceholder(Identifier.withDefaultNamespace("adventure/root")))
 					.save(consumer, Identifier.fromNamespaceAndPath(MOD_ID, "test/adventure_child"));
+
+			AdvancementHolder recipeDependent = Advancement.Builder.advancement()
+					.display(Items.POTATO,
+							Component.literal("Potato Duplication Recipe Dependent"),
+							Component.literal("You unlocked the Potato Duplication recipe."),
+							AdvancementType.GOAL,
+							false, false, false
+					)
+					.addCriterion("recipe_unlocked", RecipeUnlockedTrigger.unlocked(registryLookup.getOrThrow(POTATO_DUPLICATION_RECIPE)))
+					.parent(root)
+					.save(consumer, Identifier.fromNamespaceAndPath(MOD_ID, "test/recipe_depentent"));
 		}
 	}
 
@@ -539,6 +585,8 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 					TEST_NUMBER_PROVIDER_KEY,
 					new ConstantValue(123)
 			);
+
+			entries.add(registries.getOrThrow(POTATO_DUPLICATION_RECIPE));
 		}
 
 		@Override

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestEntrypoint.java
@@ -42,6 +42,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.minecraft.advancements.Advancement;
@@ -580,6 +581,9 @@ public class DataGeneratorTestEntrypoint implements DataGeneratorEntrypoint {
 		protected void configure(HolderLookup.Provider registries, Entries entries) {
 			registries.lookupOrThrow(Registries.LOOT_TABLE)
 					.getOrThrow(BuiltInLootTables.PIGLIN_BARTERING);
+
+			Advancement vanillaAdvancement = registries.lookupOrThrow(Registries.ADVANCEMENT).getOrThrow(ResourceKey.create(Registries.ADVANCEMENT, Identifier.withDefaultNamespace("recipes/misc/stick"))).value();
+			Advancement.CODEC.encodeStart(registries.createSerializationContext(JsonOps.INSTANCE), vanillaAdvancement).getOrThrow();
 
 			entries.add(
 					TEST_NUMBER_PROVIDER_KEY,

--- a/fabric-data-generation-api-v1/template.classtweaker
+++ b/fabric-data-generation-api-v1/template.classtweaker
@@ -21,6 +21,7 @@ extendable	method	net/minecraft/data/DataGenerator$PackGenerator	<init>	(Lnet/mi
 
 accessible	method	net/minecraft/data/registries/VanillaRegistries	validateThatAllBiomeFeaturesHaveBiomeFilter	(Lnet/minecraft/core/HolderLookup$Provider;)V
 accessible	field	net/minecraft/data/registries/VanillaRegistries	WORLD_BUILDER	Lnet/minecraft/core/RegistrySetBuilder;
+accessible	field	net/minecraft/data/registries/VanillaRegistries	RELOADABLE_BUILDER	Lnet/minecraft/core/RegistrySetBuilder;
 accessible	field	net/minecraft/core/RegistrySetBuilder	entries	Ljava/util/List;
 accessible	class	net/minecraft/core/RegistrySetBuilder$RegistryStub
 accessible	method	net/minecraft/core/RegistrySetBuilder$RegistryStub	requiredRegistries	()Ljava/util/stream/Stream;


### PR DESCRIPTION
As the title says, allows building reloadable registry entries in DataGeneratorEntrypoint, which might be required for further data generation.

Api wise a new `DataGeneratorEntrypoint#buildReloadableRegistry` method mirroring `DataGeneratorEntrypoint#buildRegistry` was introduced, matching how vanilla handles these separately