### PR TITLE
Indent enhanced switches

### DIFF
--- a/build-logic/src/main/java/net/fabricmc/fabric/impl/build/ValidateModuleTask.java
+++ b/build-logic/src/main/java/net/fabricmc/fabric/impl/build/ValidateModuleTask.java
@@ -80,13 +80,13 @@ public abstract class ValidateModuleTask extends DefaultTask {
 		}
 
 		switch ((String) moduleLifecycle) {
-		case "stable", "experimental" -> { }
-		case "deprecated" -> {
-			if (!getProjectPath().get().startsWith(":deprecated")) {
-				throw new GradleException("Deprecated module " + getProjectName().get() + " must be in the deprecated sub directory.");
+			case "stable", "experimental" -> { }
+			case "deprecated" -> {
+				if (!getProjectPath().get().startsWith(":deprecated")) {
+					throw new GradleException("Deprecated module " + getProjectName().get() + " must be in the deprecated sub directory.");
+				}
 			}
-		}
-		default -> throw new GradleException("Module " + getProjectName().get() + " has an invalid module lifecycle " + moduleLifecycle);
+			default -> throw new GradleException("Module " + getProjectName().get() + " has an invalid module lifecycle " + moduleLifecycle);
 		}
 
 		Object dependsObject = json.get("depends");

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -117,12 +117,30 @@
 			<property name="option" value="eol"/>
 		</module>
 
+		<!-- Traditional cases stay aligned with the switch; enhanced cases are indented one level. -->
 		<module name="Indentation">
+			<property name="id" value="traditionalSwitchIndentation"/>
 			<property name="basicOffset" value="4"/>
 			<property name="caseIndent" value="0"/>
 			<property name="throwsIndent" value="4"/>
 			<property name="arrayInitIndent" value="4"/>
 			<property name="lineWrappingIndentation" value="8"/>
+		</module>
+		<module name="Indentation">
+			<property name="id" value="enhancedSwitchIndentation"/>
+			<property name="basicOffset" value="4"/>
+			<property name="caseIndent" value="4"/>
+			<property name="throwsIndent" value="4"/>
+			<property name="arrayInitIndent" value="4"/>
+			<property name="lineWrappingIndentation" value="8"/>
+		</module>
+		<module name="SuppressionXpathSingleFilter">
+			<property name="id" value="traditionalSwitchIndentation"/>
+			<property name="query" value="//*[ancestor-or-self::SWITCH_RULE]"/>
+		</module>
+		<module name="SuppressionXpathSingleFilter">
+			<property name="id" value="enhancedSwitchIndentation"/>
+			<property name="query" value="//*[not(ancestor-or-self::SWITCH_RULE)]"/>
 		</module>
 
 		<module name="ParenPad"/>

--- a/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/EventResult.java
+++ b/fabric-api-base/src/main/java/net/fabricmc/fabric/api/util/EventResult.java
@@ -57,9 +57,9 @@ public enum EventResult implements StringRepresentable {
 	 */
 	public boolean allowAction(boolean passResult) {
 		return switch (this) {
-		case PASS -> passResult;
-		case ALLOW -> true;
-		case DENY -> false;
+			case PASS -> passResult;
+			case ALLOW -> true;
+			case DENY -> false;
 		};
 	}
 

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestInputImpl.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/impl/client/gametest/TestInputImpl.java
@@ -189,8 +189,8 @@ public final class TestInputImpl implements TestInput {
 
 	private static void pressOrReleaseKey(Minecraft client, InputConstants.Key key, int action) {
 		switch (key.getType()) {
-		case KEYBOARD -> ((KeyboardHandlerAccessor) client.keyboardHandler).invokeKeyPress(client.getWindow().handle(), action, new KeyEvent(key.getValue(), SDLKeyboard.SDL_GetKeyFromScancode(key.getValue(), (short) 0, false), 0));
-		case MOUSE -> ((MouseHandlerAccessor) client.mouseHandler).invokeOnButton(client.getWindow().handle(), new MouseButtonInfo(key.getValue(), 0), action);
+			case KEYBOARD -> ((KeyboardHandlerAccessor) client.keyboardHandler).invokeKeyPress(client.getWindow().handle(), action, new KeyEvent(key.getValue(), SDLKeyboard.SDL_GetKeyFromScancode(key.getValue(), (short) 0, false), 0));
+			case MOUSE -> ((MouseHandlerAccessor) client.mouseHandler).invokeOnButton(client.getWindow().handle(), new MouseButtonInfo(key.getValue(), 0), action);
 		}
 	}
 

--- a/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/screenshot/NativeImageMixin.java
+++ b/fabric-client-gametest-api-v1/src/client/java/net/fabricmc/fabric/mixin/client/gametest/screenshot/NativeImageMixin.java
@@ -49,28 +49,28 @@ public abstract class NativeImageMixin implements NativeImageHooks {
 		byte[] result = new byte[getWidth() * getHeight()];
 
 		switch (this.format) {
-		case RGBA -> {
-			for (int i = 0; i < result.length; i++) {
-				int red = MemoryUtil.memGetByte(pixels + i * 4) & 0xff;
-				int green = MemoryUtil.memGetByte(pixels + i * 4 + 1) & 0xff;
-				int blue = MemoryUtil.memGetByte(pixels + i * 4 + 2) & 0xff;
-				result[i] = toGrayscale(red, green, blue);
+			case RGBA -> {
+				for (int i = 0; i < result.length; i++) {
+					int red = MemoryUtil.memGetByte(pixels + i * 4) & 0xff;
+					int green = MemoryUtil.memGetByte(pixels + i * 4 + 1) & 0xff;
+					int blue = MemoryUtil.memGetByte(pixels + i * 4 + 2) & 0xff;
+					result[i] = toGrayscale(red, green, blue);
+				}
 			}
-		}
-		case RGB -> {
-			for (int i = 0; i < result.length; i++) {
-				int red = MemoryUtil.memGetByte(pixels + i * 3) & 0xff;
-				int green = MemoryUtil.memGetByte(pixels + i * 3 + 1) & 0xff;
-				int blue = MemoryUtil.memGetByte(pixels + i * 3 + 2) & 0xff;
-				result[i] = toGrayscale(red, green, blue);
+			case RGB -> {
+				for (int i = 0; i < result.length; i++) {
+					int red = MemoryUtil.memGetByte(pixels + i * 3) & 0xff;
+					int green = MemoryUtil.memGetByte(pixels + i * 3 + 1) & 0xff;
+					int blue = MemoryUtil.memGetByte(pixels + i * 3 + 2) & 0xff;
+					result[i] = toGrayscale(red, green, blue);
+				}
 			}
-		}
-		case LUMINANCE_ALPHA -> {
-			for (int i = 0; i < result.length; i++) {
-				result[i] = MemoryUtil.memGetByte(pixels + i * 2);
+			case LUMINANCE_ALPHA -> {
+				for (int i = 0; i < result.length; i++) {
+					result[i] = MemoryUtil.memGetByte(pixels + i * 2);
+				}
 			}
-		}
-		case LUMINANCE -> MemoryUtil.memByteBuffer(pixels, getWidth() * getHeight()).get(result);
+			case LUMINANCE -> MemoryUtil.memByteBuffer(pixels, getWidth() * getHeight()).get(result);
 		}
 
 		return result;
@@ -81,51 +81,51 @@ public abstract class NativeImageMixin implements NativeImageHooks {
 		this.checkAllocated();
 
 		return switch (this.format) {
-		case RGBA -> {
-			int[] result = this.getPixelsABGR();
+			case RGBA -> {
+				int[] result = this.getPixelsABGR();
 
-			for (int i = 0; i < result.length; i++) {
-				int color = result[i];
-				int blue = (color >> 16) & 0xff;
-				int green = (color >> 8) & 0xff;
-				int red = color & 0xff;
-				result[i] = (red << 16) | (green << 8) | blue;
+				for (int i = 0; i < result.length; i++) {
+					int color = result[i];
+					int blue = (color >> 16) & 0xff;
+					int green = (color >> 8) & 0xff;
+					int red = color & 0xff;
+					result[i] = (red << 16) | (green << 8) | blue;
+				}
+
+				yield result;
 			}
+			case RGB -> {
+				int[] result = new int[getWidth() * getHeight()];
 
-			yield result;
-		}
-		case RGB -> {
-			int[] result = new int[getWidth() * getHeight()];
+				for (int i = 0; i < result.length; i++) {
+					int red = MemoryUtil.memGetByte(pixels + i * 3) & 0xff;
+					int green = MemoryUtil.memGetByte(pixels + i * 3 + 1) & 0xff;
+					int blue = MemoryUtil.memGetByte(pixels + i * 3 + 2) & 0xff;
+					result[i] = (red << 16) | (green << 8) | blue;
+				}
 
-			for (int i = 0; i < result.length; i++) {
-				int red = MemoryUtil.memGetByte(pixels + i * 3) & 0xff;
-				int green = MemoryUtil.memGetByte(pixels + i * 3 + 1) & 0xff;
-				int blue = MemoryUtil.memGetByte(pixels + i * 3 + 2) & 0xff;
-				result[i] = (red << 16) | (green << 8) | blue;
+				yield result;
 			}
+			case LUMINANCE_ALPHA -> {
+				int[] result = new int[getWidth() * getHeight()];
 
-			yield result;
-		}
-		case LUMINANCE_ALPHA -> {
-			int[] result = new int[getWidth() * getHeight()];
+				for (int i = 0; i < result.length; i++) {
+					int luminance = MemoryUtil.memGetByte(pixels + i * 2) & 0xff;
+					result[i] = (luminance << 16) | (luminance << 8) | luminance;
+				}
 
-			for (int i = 0; i < result.length; i++) {
-				int luminance = MemoryUtil.memGetByte(pixels + i * 2) & 0xff;
-				result[i] = (luminance << 16) | (luminance << 8) | luminance;
+				yield result;
 			}
+			case LUMINANCE -> {
+				int[] result = new int[getWidth() * getHeight()];
 
-			yield result;
-		}
-		case LUMINANCE -> {
-			int[] result = new int[getWidth() * getHeight()];
+				for (int i = 0; i < result.length; i++) {
+					int luminance = MemoryUtil.memGetByte(pixels + i) & 0xff;
+					result[i] = (luminance << 16) | (luminance << 8) | luminance;
+				}
 
-			for (int i = 0; i < result.length; i++) {
-				int luminance = MemoryUtil.memGetByte(pixels + i) & 0xff;
-				result[i] = (luminance << 16) | (luminance << 8) | luminance;
+				yield result;
 			}
-
-			yield result;
-		}
 		};
 	}
 

--- a/fabric-command-api-v2/src/testmod/java/net/fabricmc/fabric/test/command/CustomArgumentTest.java
+++ b/fabric-command-api-v2/src/testmod/java/net/fabricmc/fabric/test/command/CustomArgumentTest.java
@@ -50,8 +50,8 @@ public class CustomArgumentTest implements ModInitializer {
 	private static int executeSmileyCommand(CommandContext<CommandSourceStack> context) {
 		SmileyArgument smiley = context.getArgument(ARG_NAME, SmileyArgument.class);
 		String feedback = switch (smiley) {
-		case SAD -> "Oh no, here is a heart: <3";
-		case HAPPY -> "Nice to see that you are having a good day :)";
+			case SAD -> "Oh no, here is a heart: <3";
+			case HAPPY -> "Nice to see that you are having a good day :)";
 		};
 		context.getSource().sendSuccess(() -> Component.literal(feedback), false);
 

--- a/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/ThreadPrinting.java
+++ b/fabric-crash-report-info-v1/src/main/java/net/fabricmc/fabric/impl/crash/report/info/ThreadPrinting.java
@@ -60,16 +60,16 @@ public class ThreadPrinting {
 			if (i == 0 && threadInfo.getLockInfo() != null) {
 				Thread.State ts = threadInfo.getThreadState();
 				switch (ts) {
-				case BLOCKED -> {
-					sb.append("\t-  blocked on ").append(threadInfo.getLockInfo());
-					sb.append('\n');
-				}
-				case WAITING, TIMED_WAITING -> {
-					sb.append("\t-  waiting on ").append(threadInfo.getLockInfo());
-					sb.append('\n');
-				}
-				default -> {
-				}
+					case BLOCKED -> {
+						sb.append("\t-  blocked on ").append(threadInfo.getLockInfo());
+						sb.append('\n');
+					}
+					case WAITING, TIMED_WAITING -> {
+						sb.append("\t-  waiting on ").append(threadInfo.getLockInfo());
+						sb.append('\n');
+					}
+					default -> {
+					}
 				}
 			}
 

--- a/fabric-creative-tab-api-v1/src/main/java/net/fabricmc/fabric/api/creativetab/v1/FabricCreativeModeTabOutput.java
+++ b/fabric-creative-tab-api-v1/src/main/java/net/fabricmc/fabric/api/creativetab/v1/FabricCreativeModeTabOutput.java
@@ -90,12 +90,12 @@ public class FabricCreativeModeTabOutput implements CreativeModeTab.Output {
 			checkStack(stack);
 
 			switch (visibility) {
-			case PARENT_AND_SEARCH_TABS -> {
-				this.displayStacks.add(stack);
-				this.searchTabStacks.add(stack);
-			}
-			case PARENT_TAB_ONLY -> this.displayStacks.add(stack);
-			case SEARCH_TAB_ONLY -> this.searchTabStacks.add(stack);
+				case PARENT_AND_SEARCH_TABS -> {
+					this.displayStacks.add(stack);
+					this.searchTabStacks.add(stack);
+				}
+				case PARENT_TAB_ONLY -> this.displayStacks.add(stack);
+				case SEARCH_TAB_ONLY -> this.searchTabStacks.add(stack);
 			}
 		}
 	}
@@ -119,12 +119,12 @@ public class FabricCreativeModeTabOutput implements CreativeModeTab.Output {
 			checkStack(stack);
 
 			switch (visibility) {
-			case PARENT_AND_SEARCH_TABS -> {
-				this.displayStacks.add(0, stack);
-				this.searchTabStacks.add(0, stack);
-			}
-			case PARENT_TAB_ONLY -> this.displayStacks.add(0, stack);
-			case SEARCH_TAB_ONLY -> this.searchTabStacks.add(0, stack);
+				case PARENT_AND_SEARCH_TABS -> {
+					this.displayStacks.add(0, stack);
+					this.searchTabStacks.add(0, stack);
+				}
+				case PARENT_TAB_ONLY -> this.displayStacks.add(0, stack);
+				case SEARCH_TAB_ONLY -> this.searchTabStacks.add(0, stack);
 			}
 		}
 	}
@@ -202,12 +202,12 @@ public class FabricCreativeModeTabOutput implements CreativeModeTab.Output {
 		}
 
 		switch (visibility) {
-		case PARENT_AND_SEARCH_TABS -> {
-			insertAfter(afterLast, newStacks, displayStacks);
-			insertAfter(afterLast, newStacks, searchTabStacks);
-		}
-		case PARENT_TAB_ONLY -> insertAfter(afterLast, newStacks, displayStacks);
-		case SEARCH_TAB_ONLY -> insertAfter(afterLast, newStacks, searchTabStacks);
+			case PARENT_AND_SEARCH_TABS -> {
+				insertAfter(afterLast, newStacks, displayStacks);
+				insertAfter(afterLast, newStacks, searchTabStacks);
+			}
+			case PARENT_TAB_ONLY -> insertAfter(afterLast, newStacks, displayStacks);
+			case SEARCH_TAB_ONLY -> insertAfter(afterLast, newStacks, searchTabStacks);
 		}
 	}
 
@@ -227,12 +227,12 @@ public class FabricCreativeModeTabOutput implements CreativeModeTab.Output {
 		}
 
 		switch (visibility) {
-		case PARENT_AND_SEARCH_TABS -> {
-			insertAfter(afterLast, newStacks, displayStacks);
-			insertAfter(afterLast, newStacks, searchTabStacks);
-		}
-		case PARENT_TAB_ONLY -> insertAfter(afterLast, newStacks, displayStacks);
-		case SEARCH_TAB_ONLY -> insertAfter(afterLast, newStacks, searchTabStacks);
+			case PARENT_AND_SEARCH_TABS -> {
+				insertAfter(afterLast, newStacks, displayStacks);
+				insertAfter(afterLast, newStacks, searchTabStacks);
+			}
+			case PARENT_TAB_ONLY -> insertAfter(afterLast, newStacks, displayStacks);
+			case SEARCH_TAB_ONLY -> insertAfter(afterLast, newStacks, searchTabStacks);
 		}
 	}
 
@@ -252,12 +252,12 @@ public class FabricCreativeModeTabOutput implements CreativeModeTab.Output {
 		}
 
 		switch (visibility) {
-		case PARENT_AND_SEARCH_TABS -> {
-			insertAfter(afterLast, newStacks, displayStacks);
-			insertAfter(afterLast, newStacks, searchTabStacks);
-		}
-		case PARENT_TAB_ONLY -> insertAfter(afterLast, newStacks, displayStacks);
-		case SEARCH_TAB_ONLY -> insertAfter(afterLast, newStacks, searchTabStacks);
+			case PARENT_AND_SEARCH_TABS -> {
+				insertAfter(afterLast, newStacks, displayStacks);
+				insertAfter(afterLast, newStacks, searchTabStacks);
+			}
+			case PARENT_TAB_ONLY -> insertAfter(afterLast, newStacks, displayStacks);
+			case SEARCH_TAB_ONLY -> insertAfter(afterLast, newStacks, searchTabStacks);
 		}
 	}
 
@@ -319,12 +319,12 @@ public class FabricCreativeModeTabOutput implements CreativeModeTab.Output {
 		}
 
 		switch (visibility) {
-		case PARENT_AND_SEARCH_TABS -> {
-			insertBefore(beforeFirst, newStacks, displayStacks);
-			insertBefore(beforeFirst, newStacks, searchTabStacks);
-		}
-		case PARENT_TAB_ONLY -> insertBefore(beforeFirst, newStacks, displayStacks);
-		case SEARCH_TAB_ONLY -> insertBefore(beforeFirst, newStacks, searchTabStacks);
+			case PARENT_AND_SEARCH_TABS -> {
+				insertBefore(beforeFirst, newStacks, displayStacks);
+				insertBefore(beforeFirst, newStacks, searchTabStacks);
+			}
+			case PARENT_TAB_ONLY -> insertBefore(beforeFirst, newStacks, displayStacks);
+			case SEARCH_TAB_ONLY -> insertBefore(beforeFirst, newStacks, searchTabStacks);
 		}
 	}
 
@@ -344,12 +344,12 @@ public class FabricCreativeModeTabOutput implements CreativeModeTab.Output {
 		}
 
 		switch (visibility) {
-		case PARENT_AND_SEARCH_TABS -> {
-			insertBefore(beforeFirst, newStacks, displayStacks);
-			insertBefore(beforeFirst, newStacks, searchTabStacks);
-		}
-		case PARENT_TAB_ONLY -> insertBefore(beforeFirst, newStacks, displayStacks);
-		case SEARCH_TAB_ONLY -> insertBefore(beforeFirst, newStacks, searchTabStacks);
+			case PARENT_AND_SEARCH_TABS -> {
+				insertBefore(beforeFirst, newStacks, displayStacks);
+				insertBefore(beforeFirst, newStacks, searchTabStacks);
+			}
+			case PARENT_TAB_ONLY -> insertBefore(beforeFirst, newStacks, displayStacks);
+			case SEARCH_TAB_ONLY -> insertBefore(beforeFirst, newStacks, searchTabStacks);
 		}
 	}
 
@@ -369,12 +369,12 @@ public class FabricCreativeModeTabOutput implements CreativeModeTab.Output {
 		}
 
 		switch (visibility) {
-		case PARENT_AND_SEARCH_TABS -> {
-			insertBefore(beforeFirst, newStacks, displayStacks);
-			insertBefore(beforeFirst, newStacks, searchTabStacks);
-		}
-		case PARENT_TAB_ONLY -> insertBefore(beforeFirst, newStacks, displayStacks);
-		case SEARCH_TAB_ONLY -> insertBefore(beforeFirst, newStacks, searchTabStacks);
+			case PARENT_AND_SEARCH_TABS -> {
+				insertBefore(beforeFirst, newStacks, displayStacks);
+				insertBefore(beforeFirst, newStacks, searchTabStacks);
+			}
+			case PARENT_TAB_ONLY -> insertBefore(beforeFirst, newStacks, displayStacks);
+			case SEARCH_TAB_ONLY -> insertBefore(beforeFirst, newStacks, searchTabStacks);
 		}
 	}
 

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/EnchantmentSource.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/api/item/v1/EnchantmentSource.java
@@ -63,9 +63,9 @@ public enum EnchantmentSource {
 	 */
 	public ResourceSource toResourceSource() {
 		return switch (this) {
-		case VANILLA -> ResourceSource.VANILLA;
-		case MOD -> ResourceSource.MOD;
-		case DATA_PACK -> ResourceSource.DATA_PACK;
+			case VANILLA -> ResourceSource.VANILLA;
+			case MOD -> ResourceSource.MOD;
+			case DATA_PACK -> ResourceSource.DATA_PACK;
 		};
 	}
 
@@ -80,9 +80,9 @@ public enum EnchantmentSource {
 	@Deprecated
 	public static EnchantmentSource fromResourceSource(ResourceSource source) {
 		return switch (source) {
-		case ResourceSource.VANILLA -> VANILLA;
-		case ResourceSource.MOD -> MOD;
-		case ResourceSource.DATA_PACK -> DATA_PACK;
+			case ResourceSource.VANILLA -> VANILLA;
+			case ResourceSource.MOD -> MOD;
+			case ResourceSource.DATA_PACK -> DATA_PACK;
 		};
 	}
 }

--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipProviderOrder.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/impl/item/VanillaTooltipProviderOrder.java
@@ -151,25 +151,25 @@ public final class VanillaTooltipProviderOrder {
 	private static Type unmapObjectOrArrayDesc(Type desc) {
 		MappingResolver remapper = FabricLoader.getInstance().getMappingResolver();
 		return switch (desc.getSort()) {
-		case Type.ARRAY -> {
-			Type component = desc.getElementType();
+			case Type.ARRAY -> {
+				Type component = desc.getElementType();
 
-			if (component.getSort() == Type.OBJECT) {
-				yield Type.getType(
-						"[".repeat(desc.getDimensions())
-								+ "L"
-								+ remapper.unmapClassName(
-										"official",
-										component.getClassName()
-								)
-								.replace(".", "/")
-								+ ";"
-				);
-			} else {
-				yield component;
+				if (component.getSort() == Type.OBJECT) {
+					yield Type.getType(
+							"[".repeat(desc.getDimensions())
+									+ "L"
+									+ remapper.unmapClassName(
+											"official",
+											component.getClassName()
+									)
+									.replace(".", "/")
+									+ ";"
+					);
+				} else {
+					yield component;
+				}
 			}
-		}
-		case Type.OBJECT -> Type.getType(
+			case Type.OBJECT -> Type.getType(
 				"L"
 						+ remapper.unmapClassName(
 								"official",
@@ -178,7 +178,7 @@ public final class VanillaTooltipProviderOrder {
 						.replace(".", "/")
 						+ ";"
 		);
-		default -> desc;
+			default -> desc;
 		};
 	}
 }

--- a/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CustomUnbakedBlockStateModelRegistry.java
+++ b/fabric-model-loading-api-v1/src/client/java/net/fabricmc/fabric/impl/client/model/loading/CustomUnbakedBlockStateModelRegistry.java
@@ -94,10 +94,10 @@ public class CustomUnbakedBlockStateModelRegistry {
 				Objects.requireNonNull(model);
 
 				return switch (model) {
-				case CustomUnbakedBlockStateModel custom -> DataResult.success(Either.right(Either.left(custom)));
-				case SingleVariant.Unbaked simple -> DataResult.success(Either.right(Either.right(simple)));
-				case WeightedVariants.Unbaked weighted -> DataResult.success(Either.left(weighted));
-				default -> DataResult.error(() -> "Only a custom model or a single variant or a list of variants are supported");
+					case CustomUnbakedBlockStateModel custom -> DataResult.success(Either.right(Either.left(custom)));
+					case SingleVariant.Unbaked simple -> DataResult.success(Either.right(Either.right(simple)));
+					case WeightedVariants.Unbaked weighted -> DataResult.success(Either.left(weighted));
+					default -> DataResult.error(() -> "Only a custom model or a single variant or a list of variants are supported");
 				};
 			});
 

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/AbstractChanneledNetworkAddon.java
@@ -240,9 +240,9 @@ public abstract class AbstractChanneledNetworkAddon<H> extends AbstractNetworkAd
 	@Nullable
 	private String getProtocol() {
 		return switch (receiver.getProtocol()) {
-		case PLAY -> CommonRegisterPayload.PLAY_PROTOCOL;
-		case CONFIGURATION -> CommonRegisterPayload.CONFIGURATION_PROTOCOL;
-		default -> null; // We don't support receiving this packet on any other phase
+			case PLAY -> CommonRegisterPayload.PLAY_PROTOCOL;
+			case CONFIGURATION -> CommonRegisterPayload.CONFIGURATION_PROTOCOL;
+			default -> null; // We don't support receiving this packet on any other phase
 		};
 	}
 }

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/PayloadTypeRegistryImpl.java
@@ -62,9 +62,9 @@ public class PayloadTypeRegistryImpl<B extends FriendlyByteBuf> implements Paylo
 	@Nullable
 	public static PayloadTypeRegistryImpl<?> get(ProtocolInfo<?> state) {
 		return switch (state.id()) {
-		case CONFIGURATION -> state.flow() == PacketFlow.CLIENTBOUND ? CLIENTBOUND_CONFIGURATION : SERVERBOUND_CONFIGURATION;
-		case PLAY -> state.flow() == PacketFlow.CLIENTBOUND ? CLIENTBOUND_PLAY : SERVERBOUND_PLAY;
-		default -> null;
+			case CONFIGURATION -> state.flow() == PacketFlow.CLIENTBOUND ? CLIENTBOUND_CONFIGURATION : SERVERBOUND_CONFIGURATION;
+			case PLAY -> state.flow() == PacketFlow.CLIENTBOUND ? CLIENTBOUND_PLAY : SERVERBOUND_PLAY;
+			default -> null;
 		};
 	}
 

--- a/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/VanillaPacketTypes.java
+++ b/fabric-networking-api-v1/src/main/java/net/fabricmc/fabric/impl/networking/VanillaPacketTypes.java
@@ -48,9 +48,9 @@ public record VanillaPacketTypes(PacketType<?>[] types) {
 
 	public static VanillaPacketTypes get(ProtocolInfo<?> protocolInfo) {
 		return switch (protocolInfo.id()) {
-		case CONFIGURATION -> protocolInfo.flow() == PacketFlow.CLIENTBOUND ? CONFIGURATION_S2C : CONFIGURATION_C2S;
-		case PLAY -> protocolInfo.flow() == PacketFlow.CLIENTBOUND ? PLAY_S2C : PLAY_C2S;
-		default -> throw new IllegalArgumentException("Not implemented for " + protocolInfo.id() + "!");
+			case CONFIGURATION -> protocolInfo.flow() == PacketFlow.CLIENTBOUND ? CONFIGURATION_S2C : CONFIGURATION_C2S;
+			case PLAY -> protocolInfo.flow() == PacketFlow.CLIENTBOUND ? PLAY_S2C : PLAY_C2S;
+			default -> throw new IllegalArgumentException("Not implemented for " + protocolInfo.id() + "!");
 		};
 	}
 }

--- a/fabric-permission-api-v1/src/main/java/net/fabricmc/fabric/mixin/permission/CommandSourceStackMixin.java
+++ b/fabric-permission-api-v1/src/main/java/net/fabricmc/fabric/mixin/permission/CommandSourceStackMixin.java
@@ -52,13 +52,13 @@ public abstract class CommandSourceStackMixin implements PermissionContextOwner,
 	@Inject(method = "<init>(Lnet/minecraft/commands/CommandSource;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec2;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/server/permissions/PermissionSet;Lnet/minecraft/commands/CommandSourceStack$NamesProvider;Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/world/entity/Entity;)V", at = @At("TAIL"))
 	private void storeOriginalSource(CommandSource source, Vec3 position, Vec2 rotation, ServerLevel level, PermissionSet permissions, CommandSourceStack.NamesProvider namesProvider, MinecraftServer server, Entity entity, CallbackInfo ci) {
 		this.sourceType = switch (entity) {
-		case Player _ -> PermissionContext.Type.PLAYER;
-		case Entity _ -> PermissionContext.Type.ENTITY;
-		case null -> PermissionContext.Type.SYSTEM;
+			case Player _ -> PermissionContext.Type.PLAYER;
+			case Entity _ -> PermissionContext.Type.ENTITY;
+			case null -> PermissionContext.Type.SYSTEM;
 		};
 		this.sourceUuid = switch (entity) {
-		case Entity _ -> entity.getUUID();
-		case null -> Util.NIL_UUID;
+			case Entity _ -> entity.getUUID();
+			case null -> Util.NIL_UUID;
 		};
 	}
 

--- a/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientSync.java
+++ b/fabric-recipe-api-v1/src/main/java/net/fabricmc/fabric/impl/recipe/ingredient/CustomIngredientSync.java
@@ -59,15 +59,15 @@ public class CustomIngredientSync implements ModInitializer {
 	public static Set<Identifier> decodeResponsePayload(ServerboundCustomIngredientPayload payload) {
 		int protocolVersion = payload.protocolVersion();
 		switch (protocolVersion) {
-		case PROTOCOL_VERSION_1 -> {
-			Set<Identifier> serializers = payload.registeredSerializers();
-			// Remove unknown keys to save memory
-			serializers.removeIf(id -> !CustomIngredientImpl.REGISTERED_SERIALIZERS.containsKey(id));
-			return serializers;
-		}
-		default -> {
-			throw new IllegalArgumentException("Unknown ingredient sync protocol version: " + protocolVersion);
-		}
+			case PROTOCOL_VERSION_1 -> {
+				Set<Identifier> serializers = payload.registeredSerializers();
+				// Remove unknown keys to save memory
+				serializers.removeIf(id -> !CustomIngredientImpl.REGISTERED_SERIALIZERS.containsKey(id));
+				return serializers;
+			}
+			default -> {
+				throw new IllegalArgumentException("Unknown ingredient sync protocol version: " + protocolVersion);
+			}
 		}
 	}
 

--- a/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
+++ b/fabric-registry-sync-v0/src/main/java/net/fabricmc/fabric/impl/registry/sync/RegistrySyncManager.java
@@ -95,8 +95,8 @@ public final class RegistrySyncManager {
 
 	private static Component getIncompatibleClientComponent(@Nullable String brand, Map<Identifier, Object2IntMap<Identifier>> map) {
 		String brandText = switch (brand) {
-		case "fabric" -> "Fabric API";
-		case null, default -> "Fabric Loader and Fabric API";
+			case "fabric" -> "Fabric API";
+			case null, default -> "Fabric Loader and Fabric API";
 		};
 
 		final int toDisplay = 4;

--- a/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/ChunkSectionLayerHelper.java
+++ b/fabric-renderer-api-v1/src/client/java/net/fabricmc/fabric/api/client/renderer/v1/render/ChunkSectionLayerHelper.java
@@ -27,9 +27,9 @@ public final class ChunkSectionLayerHelper {
 
 	public static RenderType getMovingBlockRenderType(ChunkSectionLayer layer) {
 		return switch (layer) {
-		case SOLID -> RenderTypes.solidMovingBlock();
-		case CUTOUT -> RenderTypes.cutoutMovingBlock();
-		case TRANSLUCENT -> RenderTypes.translucentMovingBlock();
+			case SOLID -> RenderTypes.solidMovingBlock();
+			case CUTOUT -> RenderTypes.cutoutMovingBlock();
+			case TRANSLUCENT -> RenderTypes.translucentMovingBlock();
 		};
 	}
 

--- a/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/BuiltInMeshUnbakedModelDeserializer.java
+++ b/fabric-renderer-api-v1/src/testmodClient/java/net/fabricmc/fabric/test/renderer/client/BuiltInMeshUnbakedModelDeserializer.java
@@ -35,12 +35,12 @@ public class BuiltInMeshUnbakedModelDeserializer extends SimpleUnbakedModelDeser
 		String meshId = GsonHelper.getAsString(object, "mesh");
 
 		return switch (meshId) {
-		case "emissive_frame" -> new FrameGeometry(true);
-		case "frame" -> new FrameGeometry(false);
-		case "pillar" -> new PillarGeometry();
-		case "octagonal_column_enhanced" -> new OctagonalColumnGeometry(ShadeMode.ENHANCED);
-		case "octagonal_column_vanilla" -> new OctagonalColumnGeometry(ShadeMode.VANILLA);
-		default -> throw new IllegalArgumentException("Invalid mesh ID: " + meshId);
+			case "emissive_frame" -> new FrameGeometry(true);
+			case "frame" -> new FrameGeometry(false);
+			case "pillar" -> new PillarGeometry();
+			case "octagonal_column_enhanced" -> new OctagonalColumnGeometry(ShadeMode.ENHANCED);
+			case "octagonal_column_vanilla" -> new OctagonalColumnGeometry(ShadeMode.VANILLA);
+			default -> throw new IllegalArgumentException("Invalid mesh ID: " + meshId);
 		};
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/Indigo.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/Indigo.java
@@ -78,9 +78,9 @@ public class Indigo implements ClientModInitializer {
 		}
 
 		return switch (property.toLowerCase(Locale.ROOT)) {
-		case "true" -> TriState.TRUE;
-		case "false" -> TriState.FALSE;
-		default -> TriState.DEFAULT;
+			case "true" -> TriState.TRUE;
+			case "false" -> TriState.FALSE;
+			default -> TriState.DEFAULT;
 		};
 	}
 

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoCalculator.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/aocalc/AoCalculator.java
@@ -99,16 +99,16 @@ public class AoCalculator {
 		final AoConfig config = Indigo.AMBIENT_OCCLUSION_MODE;
 
 		switch (config) {
-		case VANILLA -> calcVanilla(quad);
-		case EMULATE -> calcFastVanilla(quad);
-		case HYBRID -> {
-			if (vanillaShade) {
-				calcFastVanilla(quad);
-			} else {
-				calcEnhanced(quad);
+			case VANILLA -> calcVanilla(quad);
+			case EMULATE -> calcFastVanilla(quad);
+			case HYBRID -> {
+				if (vanillaShade) {
+					calcFastVanilla(quad);
+				} else {
+					calcEnhanced(quad);
+				}
 			}
-		}
-		case ENHANCED -> calcEnhanced(quad);
+			case ENHANCED -> calcEnhanced(quad);
 		}
 
 		if (Indigo.DEBUG_COMPARE_LIGHTING && vanillaShade && (config == AoConfig.EMULATE || config == AoConfig.HYBRID)) {

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/helper/GeometryHelper.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/helper/GeometryHelper.java
@@ -247,33 +247,33 @@ public final class GeometryHelper {
 		final boolean b;
 
 		switch (quad.lightFace()) {
-		case DOWN -> {
-			a = x > EPS_MIN;
-			b = z < EPS_MAX;
-		}
-		case UP -> {
-			a = x > EPS_MIN;
-			b = z > EPS_MIN;
-		}
-		case NORTH -> {
-			a = x < EPS_MAX;
-			b = y < EPS_MAX;
-		}
-		case SOUTH -> {
-			a = x > EPS_MIN;
-			b = y < EPS_MAX;
-		}
-		case WEST -> {
-			a = z > EPS_MIN;
-			b = y < EPS_MAX;
-		}
-		case EAST -> {
-			a = z < EPS_MAX;
-			b = y < EPS_MAX;
-		}
-		default -> {
-			return 0;
-		}
+			case DOWN -> {
+				a = x > EPS_MIN;
+				b = z < EPS_MAX;
+			}
+			case UP -> {
+				a = x > EPS_MIN;
+				b = z > EPS_MIN;
+			}
+			case NORTH -> {
+				a = x < EPS_MAX;
+				b = y < EPS_MAX;
+			}
+			case SOUTH -> {
+				a = x > EPS_MIN;
+				b = y < EPS_MAX;
+			}
+			case WEST -> {
+				a = z > EPS_MIN;
+				b = y < EPS_MAX;
+			}
+			case EAST -> {
+				a = z < EPS_MAX;
+				b = y < EPS_MAX;
+			}
+			default -> {
+				return 0;
+			}
 		}
 
 		int result = 0;

--- a/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ExtendedItemFeatureRenderer.java
+++ b/fabric-renderer-indigo/src/client/java/net/fabricmc/fabric/impl/client/indigo/renderer/render/ExtendedItemFeatureRenderer.java
@@ -109,9 +109,9 @@ public class ExtendedItemFeatureRenderer extends RenderTypeFeatureRenderer<Exten
 		ItemStackRenderState.FoilType foilType = quadFoilType == null ? submit.foilType() : quadFoilType;
 
 		RenderType renderType = switch (foilType) {
-		case NONE -> quad.itemRenderType();
-		case STANDARD -> quad.itemGlintRenderType();
-		case SPECIAL -> quad.itemGlintSpecialRenderType();
+			case NONE -> quad.itemRenderType();
+			case STANDARD -> quad.itemGlintRenderType();
+			case SPECIAL -> quad.itemGlintSpecialRenderType();
 		};
 
 		VertexConsumer vertexConsumer = getVertexBuilder(renderType);

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/pack/ModPackResourcesSorter.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/pack/ModPackResourcesSorter.java
@@ -106,8 +106,8 @@ public class ModPackResourcesSorter {
 			LoadPhaseData second = getOrCreatePhase(secondPhase, false);
 
 			switch (order) {
-			case BEFORE -> LoadPhaseData.link(first, second);
-			case AFTER -> LoadPhaseData.link(second, first);
+				case BEFORE -> LoadPhaseData.link(first, second);
+				case AFTER -> LoadPhaseData.link(second, first);
 			}
 
 			NodeSorting.sort(this.sortedPhases, "event phases", Comparator.comparing(data -> data.modId));

--- a/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/pack/ModPackResourcesUtil.java
+++ b/fabric-resource-loader-v1/src/main/java/net/fabricmc/fabric/impl/resource/pack/ModPackResourcesUtil.java
@@ -126,18 +126,18 @@ public final class ModPackResourcesUtil {
 		if (array == null) return;
 
 		switch (array.getType()) {
-		case STRING -> modIds.add(array.getAsString());
-		case ARRAY -> {
-			for (CustomValue id : array.getAsArray()) {
-				if (id.getType() == CustomValue.CvType.STRING) {
-					modIds.add(id.getAsString());
+			case STRING -> modIds.add(array.getAsString());
+			case ARRAY -> {
+				for (CustomValue id : array.getAsArray()) {
+					if (id.getType() == CustomValue.CvType.STRING) {
+						modIds.add(id.getAsString());
+					}
 				}
 			}
-		}
-		default -> {
-			LOGGER.error("[Fabric] {} should be a string or an array", order.jsonKey);
-			return;
-		}
+			default -> {
+				LOGGER.error("[Fabric] {} should be a string or an array", order.jsonKey);
+				return;
+			}
 		}
 
 		modIds.stream().filter(allIds::contains).forEach(modId -> sorter.addLoadOrdering(modId, currentId, order));

--- a/fabric-tag-api-v1/src/main/java/net/fabricmc/fabric/impl/tag/TagAliasLoader.java
+++ b/fabric-tag-api-v1/src/main/java/net/fabricmc/fabric/impl/tag/TagAliasLoader.java
@@ -74,13 +74,13 @@ public final class TagAliasLoader extends SimpleReloadListener<Map<ResourceKey<?
 					Codec<TagAliasGroup<Object>> codec = TagAliasGroup.codec((ResourceKey<? extends Registry<Object>>) resourceKey);
 
 					switch (codec.parse(JsonOps.INSTANCE, json)) {
-					case DataResult.Success(TagAliasGroup<Object> group, Lifecycle unused) -> {
-						var data = new Data(groupId, group);
-						dataByRegistry.computeIfAbsent(resourceKey, key -> new ArrayList<>()).add(data);
-					}
-					case DataResult.Error<?> error -> {
-						LOGGER.error("[Fabric] Couldn't parse tag alias group file '{}' from '{}': {}", groupId, resourcePath, error.message());
-					}
+						case DataResult.Success(TagAliasGroup<Object> group, Lifecycle unused) -> {
+							var data = new Data(groupId, group);
+							dataByRegistry.computeIfAbsent(resourceKey, key -> new ArrayList<>()).add(data);
+						}
+						case DataResult.Error<?> error -> {
+							LOGGER.error("[Fabric] Couldn't parse tag alias group file '{}' from '{}': {}", groupId, resourcePath, error.message());
+						}
 					}
 				} catch (IOException | JsonParseException e) {
 					LOGGER.error("[Fabric] Couldn't parse tag alias group file '{}' from '{}'", groupId, resourcePath, e);

--- a/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/BundleContentsStorage.java
+++ b/fabric-transfer-api-v1/src/main/java/net/fabricmc/fabric/impl/transfer/item/BundleContentsStorage.java
@@ -194,8 +194,8 @@ public class BundleContentsStorage implements Storage<ItemVariant> {
 
 		private static Fraction getWeight(DataResult<Fraction> weight) {
 			return switch (weight) {
-			case DataResult.Success<Fraction> success -> success.value();
-			case DataResult.Error<Fraction> ignored -> Fraction.ONE;
+				case DataResult.Success<Fraction> success -> success.value();
+				case DataResult.Error<Fraction> ignored -> Fraction.ONE;
 			};
 		}
 	}


### PR DESCRIPTION
Indents all case labels in enhanced switch statements (those with `->`) while leaving others intact. I personally would be in favour of indenting all case labels unconditionally, but it seems that's not what we want.

In the checkstyle, the `Indentation` module had to be duplicated to get this to work.

To indent all the switch statements, I vibecoded [this script](https://gist.github.com/Earthcomputer/b095da116a92d05d5f41662f2cd03129) and ran it on the project. I did not review the script itself, however I did review the output and it all looks fine, and checkstyle passes afterwards.