### PR TITLE
Fix hud status bars for height != 10

### DIFF
--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/hud/HudStatusBarHeightRegistry.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/hud/HudStatusBarHeightRegistry.java
@@ -107,26 +107,37 @@ public final class HudStatusBarHeightRegistry {
 		HudStatusBarHeightRegistryImpl.addRight(id, heightProvider);
 	}
 
-	/**
-	 * Gets the total calculated height offset for a given HUD element ID. Usage:
-	 * {@snippet :
-	 * - net.minecraft.client.gui.GuiGraphics.guiHeight() - (39 + renderHeight)
-	 * + net.minecraft.client.gui.GuiGraphics.guiHeight() - HudStatusBarHeightRegistry.getHeight(id)
-	 * }
-	 *
-	 * <p>This method is typically used by the rendering system to determine how much
-	 * to shift a HUD element. It returns the default HUD height which is {@code 39} plus the sum of all registered
-	 * provider heights that are considered "below" the position of the element associated with the given {@code id}.
-	 *
-	 * <p>Note: The registry must be initialized (frozen) before this method returns
-	 * values without throwing an exception. This initialization happens during the Minecraft client setup.
-	 *
-	 * @param id the {@link Identifier} of the HUD element.
-	 * @return the total height offset.
-	 */
+	/// Gets the total calculated Y offset for a given HUD element ID
+	/// from the bottom of the screen to the top of the element.
+	///
+	/// Usage:
+	/// ```diff
+	/// - net.minecraft.client.gui.GuiGraphics.guiHeight() - (39 + renderHeight)
+	/// + net.minecraft.client.gui.GuiGraphics.guiHeight() - HudStatusBarHeightRegistry.getHeight(id)
+	/// ```
+	///
+	/// This method is typically used by the rendering system to determine how much to shift a HUD element.
+	/// It returns the default HUD height which is `24` plus the sum of all registered provider heights
+	/// including and below the position of the element associated with the given `id`.
+	/// Earlier hud elements are considered to be below later ones.
+	///
+	/// Note: The registry must be initialized (frozen) before this method returns
+	/// values without throwing an exception. This initialization happens during the Minecraft client setup.
+	///
+	/// @param id the [Identifier] of the HUD element.
+	/// @return the total Y offset from the bottom of the screen to the top of the element.
 	public static int getHeight(Identifier id) {
 		Objects.requireNonNull(id, "id is null");
 		return HudStatusBarHeightRegistryImpl.getHeight(id);
+	}
+
+	/// Gets the height of the given HUD element ID.
+	///
+	/// @param id the [Identifier] of the HUD element.
+	/// @return the height of the element.
+	public static int getElementHeight(Identifier id) {
+		Objects.requireNonNull(id, "id is null");
+		return HudStatusBarHeightRegistryImpl.getElementHeight(id);
 	}
 
 	private HudStatusBarHeightRegistry() {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudStatusBarHeightRegistryImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudStatusBarHeightRegistryImpl.java
@@ -21,6 +21,8 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.SequencedCollection;
 import java.util.SequencedSet;
 import java.util.Set;
@@ -230,6 +232,31 @@ public final class HudStatusBarHeightRegistryImpl implements ClientModInitialize
 		return DEFAULT_HEIGHT + yPosProviders.get(id).getYPos(player);
 	}
 
+	public static int getElementHeight(Identifier id) {
+		if (yPosProviders == null) {
+			throw new IllegalStateException("Trying to get status bar height for " + id + " too early");
+		}
+
+		Player player = ((HudAccessor) Minecraft.getInstance().gui.hud).fabric$callGetCameraPlayer();
+
+		if (player == null) {
+			throw new IllegalStateException("Trying to get status bar height for " + id + " without a camera player");
+		}
+
+		OptionalInt left = Optional.ofNullable(LEFT_HEIGHT_PROVIDERS.get(id)).map(provider -> OptionalInt.of(provider.getStatusBarHeight(player))).orElse(OptionalInt.empty());
+		OptionalInt right = Optional.ofNullable(RIGHT_HEIGHT_PROVIDERS.get(id)).map(provider -> OptionalInt.of(provider.getStatusBarHeight(player))).orElse(OptionalInt.empty());
+
+		if (left.isEmpty() && right.isEmpty()) {
+			throw new IllegalArgumentException("Unknown status bar: " + id);
+		}
+
+		if (left.isPresent() && right.isPresent() && left.getAsInt() != right.getAsInt()) {
+			throw new IllegalStateException("Status bar " + id + " has different heights registered for left and right sides: " + left.getAsInt() + " vs " + right.getAsInt());
+		}
+
+		return left.orElseGet(right::getAsInt);
+	}
+
 	static void init() {
 		// skip resolving if no custom height providers have been registered
 		if (LEFT_VANILLA_HEIGHT_PROVIDERS.equals(LEFT_HEIGHT_PROVIDERS) && RIGHT_VANILLA_HEIGHT_PROVIDERS.equals(
@@ -367,8 +394,17 @@ public final class HudStatusBarHeightRegistryImpl implements ClientModInitialize
 	}
 
 	private static boolean isVanillaHeightProvider(Identifier id) {
-		return LEFT_HEIGHT_PROVIDERS.containsKey(id) && LEFT_HEIGHT_PROVIDERS.get(id) == LEFT_VANILLA_HEIGHT_PROVIDERS.get(id)
-				|| RIGHT_HEIGHT_PROVIDERS.containsKey(id) && RIGHT_HEIGHT_PROVIDERS.get(id) == RIGHT_VANILLA_HEIGHT_PROVIDERS.get(id);
+		if (LEFT_HEIGHT_PROVIDERS.containsKey(id) && LEFT_HEIGHT_PROVIDERS.get(id) == LEFT_VANILLA_HEIGHT_PROVIDERS.get(
+				id)) {
+			return true;
+		}
+
+		if (RIGHT_HEIGHT_PROVIDERS.containsKey(id)
+				&& RIGHT_HEIGHT_PROVIDERS.get(id) == RIGHT_VANILLA_HEIGHT_PROVIDERS.get(id)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private static void replaceVanillaElement(Identifier id, YPosProvider yPosProvider) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudStatusBarHeightRegistryImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudStatusBarHeightRegistryImpl.java
@@ -58,10 +58,9 @@ import net.fabricmc.fabric.mixin.client.rendering.HudAccessor;
 
 public final class HudStatusBarHeightRegistryImpl implements ClientModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger("fabric-rendering-v1");
-	/**
-	 * The height at which vanilla begins rendering status bars; this is used for health and food / mount health.
-	 */
-	static final int DEFAULT_HEIGHT = 29;
+	/// The height at which vanilla begins rendering status bars; this is used for the info bar.
+	/// This number is derived from the `- 24 - 5` in [net.minecraft.client.gui.contextualbar.ContextualBar#top].
+	static final int DEFAULT_HEIGHT = 24;
 	/**
 	 * The height at which the held item tooltip renders in vanilla; for our purposes we already subtract the default
 	 * height.
@@ -76,7 +75,7 @@ public final class HudStatusBarHeightRegistryImpl implements ClientModInitialize
 	/**
 	 * Height provider for the vanilla info bar.
 	 */
-	static final StatusBarHeightProvider INFO_BAR = _ -> 10;
+	static final StatusBarHeightProvider INFO_BAR = _ -> 5;
 	/**
 	 * Height provider for the vanilla health bar.
 	 */
@@ -305,13 +304,19 @@ public final class HudStatusBarHeightRegistryImpl implements ClientModInitialize
 		// combines all height providers "below" a hud element for determining the height at which it should render at
 		YPosProvider yPosProvider = YPosProvider.ZERO;
 
-		for (Identifier heightProviderLocation : orderedHeightProviders) {
-			if (heightProviderLocation.equals(id)) {
+		for (Identifier heightProviderId : orderedHeightProviders) {
+			if (heightProviderLookup.containsKey(heightProviderId)) {
+				yPosProvider = reduceToIntFunctions(
+						yPosProvider,
+						heightProviderLookup.get(heightProviderId),
+						Integer::sum
+				);
+			}
+			// We include the hud element (id)'s own height provider because textures are rendered starting from the top left,
+			// so getHeight(id) should include the hud element's own height in order for GuiGraphics.guiHeight() - getHeight(id)
+			// to be at the top of where the hud element should render.
+			if (heightProviderId.equals(id)) {
 				return yPosProvider;
-			} else if (heightProviderLookup.containsKey(heightProviderLocation)) {
-				yPosProvider = reduceToIntFunctions(yPosProvider,
-						heightProviderLookup.get(heightProviderLocation),
-						Integer::sum);
 			}
 		}
 
@@ -361,17 +366,8 @@ public final class HudStatusBarHeightRegistryImpl implements ClientModInitialize
 	}
 
 	private static boolean isVanillaHeightProvider(Identifier id) {
-		if (LEFT_HEIGHT_PROVIDERS.containsKey(id) && LEFT_HEIGHT_PROVIDERS.get(id) == LEFT_VANILLA_HEIGHT_PROVIDERS.get(
-				id)) {
-			return true;
-		}
-
-		if (RIGHT_HEIGHT_PROVIDERS.containsKey(id)
-				&& RIGHT_HEIGHT_PROVIDERS.get(id) == RIGHT_VANILLA_HEIGHT_PROVIDERS.get(id)) {
-			return true;
-		}
-
-		return false;
+		return LEFT_HEIGHT_PROVIDERS.containsKey(id) && LEFT_HEIGHT_PROVIDERS.get(id) == LEFT_VANILLA_HEIGHT_PROVIDERS.get(id)
+				|| RIGHT_HEIGHT_PROVIDERS.containsKey(id) && RIGHT_HEIGHT_PROVIDERS.get(id) == RIGHT_VANILLA_HEIGHT_PROVIDERS.get(id);
 	}
 
 	private static void replaceVanillaElement(Identifier id, YPosProvider yPosProvider) {

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudStatusBarHeightRegistryImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudStatusBarHeightRegistryImpl.java
@@ -312,6 +312,7 @@ public final class HudStatusBarHeightRegistryImpl implements ClientModInitialize
 						Integer::sum
 				);
 			}
+
 			// We include the hud element (id)'s own height provider because textures are rendered starting from the top left,
 			// so getHeight(id) should include the hud element's own height in order for GuiGraphics.guiHeight() - getHeight(id)
 			// to be at the top of where the hud element should render.

--- a/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudStatusBarHeightRegistryImpl.java
+++ b/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/impl/client/rendering/hud/HudStatusBarHeightRegistryImpl.java
@@ -129,17 +129,17 @@ public final class HudStatusBarHeightRegistryImpl implements ClientModInitialize
 	 */
 	static final Map<Identifier, YPosProvider> VANILLA_Y_POS_PROVIDERS = ImmutableMap.of(
 			VanillaHudElements.INFO_BAR,
-			YPosProvider.ZERO,
+			INFO_BAR::getStatusBarHeight,
 			VanillaHudElements.HEALTH_BAR,
-			INFO_BAR::getStatusBarHeight,
+			reduceToIntFunctions(INFO_BAR, HEALTH_BAR, Integer::sum),
 			VanillaHudElements.ARMOR_BAR,
-			HEALTH_BAR::getStatusBarHeight,
+			reduceToIntFunctions(reduceToIntFunctions(INFO_BAR, HEALTH_BAR, Integer::sum), ARMOR_BAR, Integer::sum),
 			VanillaHudElements.MOUNT_HEALTH,
-			INFO_BAR::getStatusBarHeight,
+			reduceToIntFunctions(INFO_BAR, MOUNT_HEALTH, Integer::sum),
 			VanillaHudElements.FOOD_BAR,
-			INFO_BAR::getStatusBarHeight,
+			reduceToIntFunctions(reduceToIntFunctions(INFO_BAR, MOUNT_HEALTH, Integer::sum), FOOD_BAR, Integer::sum),
 			VanillaHudElements.AIR_BAR,
-			reduceToIntFunctions(reduceToIntFunctions(INFO_BAR, MOUNT_HEALTH, Integer::sum), FOOD_BAR, Integer::sum));
+			reduceToIntFunctions(reduceToIntFunctions(INFO_BAR, MOUNT_HEALTH, Integer::sum), reduceToIntFunctions(FOOD_BAR, AIR_BAR, Integer::sum), Integer::sum));
 	/**
 	 * Height providers registered for the left side above the hotbar.
 	 *

--- a/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/HudStatusBarHeightsTest.java
+++ b/fabric-rendering-v1/src/testmodClient/java/net/fabricmc/fabric/test/rendering/client/HudStatusBarHeightsTest.java
@@ -18,7 +18,6 @@ package net.fabricmc.fabric.test.rendering.client;
 
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.Hud;
 import net.minecraft.client.renderer.RenderPipelines;
@@ -135,6 +134,7 @@ public class HudStatusBarHeightsTest implements ClientModInitializer {
 
 	private static void testStaminaBar() {
 		// register a stamina bar showing above the vanilla food bar
+		// 20 pixels to test bars of different heights
 		Identifier id = Identifier.fromNamespaceAndPath("fabric-rendering-v1-testmod", "stamina_bar");
 		HudElementRegistry.attachElementAfter(VanillaHudElements.FOOD_BAR,
 				id,
@@ -148,10 +148,8 @@ public class HudStatusBarHeightsTest implements ClientModInitializer {
 						if (((HudAccessor) hud).fabric$callGetHeartCount(livingEntity) == 0) {
 							int width = graphics.guiWidth() / 2 + 91;
 							int height = graphics.guiHeight() - HudStatusBarHeightRegistry.getHeight(id);
-							extractStamina(graphics,
-									((HudAccessor) hud).fabric$callGetCameraPlayer(),
-									height,
-									width);
+							extractStamina(graphics, ((HudAccessor) hud).fabric$callGetCameraPlayer(), height, width);
+							extractStamina(graphics, ((HudAccessor) hud).fabric$callGetCameraPlayer(), height + 10, width);
 						}
 					}
 				});
@@ -163,7 +161,7 @@ public class HudStatusBarHeightsTest implements ClientModInitializer {
 				LivingEntity livingEntity = ((HudAccessor) hud).fabric$callGetRiddenEntity();
 
 				if (((HudAccessor) hud).fabric$callGetHeartCount(livingEntity) == 0) {
-					return 10;
+					return 20;
 				}
 			}
 
@@ -172,7 +170,7 @@ public class HudStatusBarHeightsTest implements ClientModInitializer {
 	}
 
 	/**
-	 * @see Gui#extractArmor(GuiGraphicsExtractor, Player, int, int, int, int)
+	 * @see Hud#extractArmor(GuiGraphicsExtractor, Player, int, int, int, int)
 	 */
 	private static void extractHealth(GuiGraphicsExtractor graphics, Player player, int y, int heartRows, int height, int x) {
 		int l = Mth.floor(player.getHealth());
@@ -196,7 +194,7 @@ public class HudStatusBarHeightsTest implements ClientModInitializer {
 	}
 
 	/**
-	 * @see Gui#extractArmor(GuiGraphicsExtractor, Player, int, int, int, int)
+	 * @see Hud#extractArmor(GuiGraphicsExtractor, Player, int, int, int, int)
 	 */
 	private static void extractArmor(GuiGraphicsExtractor graphics, Player player, int y, int heartRows, int height, int x) {
 		int l = player.getArmorValue();
@@ -219,7 +217,7 @@ public class HudStatusBarHeightsTest implements ClientModInitializer {
 	}
 
 	/**
-	 * @see Gui#extractArmor(GuiGraphicsExtractor, Player, int, int, int, int)
+	 * @see Hud#extractArmor(GuiGraphicsExtractor, Player, int, int, int, int)
 	 */
 	private static void extractToughness(GuiGraphicsExtractor graphics, Player player, int y, int heartRows, int height, int x) {
 		int i = Mth.floor(player.getAttributeValue(Attributes.ARMOR_TOUGHNESS));
@@ -246,7 +244,7 @@ public class HudStatusBarHeightsTest implements ClientModInitializer {
 	}
 
 	/**
-	 * @see Gui#extractFood(GuiGraphicsExtractor, Player, int, int)
+	 * @see Hud#extractFood(GuiGraphicsExtractor, Player, int, int)
 	 */
 	private static void extractStamina(GuiGraphicsExtractor graphics, Player player, int y, int x) {
 		int k = player.getFoodData().getFoodLevel();


### PR DESCRIPTION
Currently, registering a status bar with height not equals to 0 or 10 results in overlap, as the bar's own height is not included in the calculation for its y position. Previously, all test bars were of height 10, so this bug did not surface.

There is no game test because there is a pending game test in #5577 that would conflict. These two prs will probably conflict anyways, so I'll update after one of them gets merged.

Without this pr (without the changes to the impl, but with the changes to the test in this pr):
<img width="966" height="620" alt="Screenshot 2026-09-07 at 16 58 38" src="https://github.com/user-attachments/assets/f6b8d082-9a42-48e0-8316-da3efb4c7e81" />
With this pr:
<img width="966" height="620" alt="Screenshot 2026-09-07 at 16 59 19" src="https://github.com/user-attachments/assets/b74ce26b-3a9a-4f88-a9d3-e71c1b3287a6" />
