### PR TITLE
Fix vanilla killAllMobs advancement check failing due to modded entities.

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/advancement/VanillaAdventureAdvancementsMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/advancement/VanillaAdventureAdvancementsMixin.java
@@ -1,0 +1,22 @@
+package net.fabricmc.fabric.mixin.datagen.advancement;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import net.minecraft.core.Holder;
+import net.minecraft.data.advancements.packs.VanillaAdventureAdvancements;
+
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.EntityType;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.stream.Stream;
+
+@Mixin(VanillaAdventureAdvancements.class)
+public class VanillaAdventureAdvancementsMixin {
+	@ModifyExpressionValue(method = "validateMobsToKill", at = @At(value = "INVOKE", target = "Lnet/minecraft/data/worldgen/BootstrapContext;listContextElements(Lnet/minecraft/resources/ResourceKey;)Ljava/util/stream/Stream;"))
+	private Stream<Holder.Reference<EntityType<?>>> onlyCheckVanillaEntities(Stream<Holder.Reference<EntityType<?>>> entities) {
+		return entities.filter(entity -> entity.key().identifier().getNamespace().equals(Identifier.DEFAULT_NAMESPACE));
+	}
+}

--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/advancement/VanillaAdventureAdvancementsMixin.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/advancement/VanillaAdventureAdvancementsMixin.java
@@ -1,17 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.datagen.advancement;
 
+import java.util.stream.Stream;
+
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-
-import net.minecraft.core.Holder;
-import net.minecraft.data.advancements.packs.VanillaAdventureAdvancements;
-
-import net.minecraft.resources.Identifier;
-import net.minecraft.world.entity.EntityType;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-import java.util.stream.Stream;
+import net.minecraft.core.Holder;
+import net.minecraft.data.advancements.packs.VanillaAdventureAdvancements;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.EntityType;
 
 @Mixin(VanillaAdventureAdvancements.class)
 public class VanillaAdventureAdvancementsMixin {

--- a/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
+++ b/fabric-data-generation-api-v1/src/main/resources/fabric-data-generation-api-v1.mixins.json
@@ -12,6 +12,7 @@
     "TagBuilderMixin",
     "TagsProviderMixin",
     "advancement.AdvancementBuilderMixin",
+    "advancement.VanillaAdventureAdvancementsMixin",
     "loot.BlockLootSubProviderAccessor",
     "loot.BlockLootSubProviderMixin",
     "loot.EntityLootSubProviderAccessor",

--- a/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
+++ b/fabric-data-generation-api-v1/src/testmod/java/net/fabricmc/fabric/test/datagen/DataGeneratorTestContent.java
@@ -106,7 +106,7 @@ public class DataGeneratorTestContent implements ModInitializer {
 		BLOCK_WITH_VANILLA_LOOT_TABLE = createBlock(BLOCK_WITH_VANILLA_LOOT_TABLE_KEY, BlockBehaviour.Properties.of().overrideLootTable(Blocks.STONE.getLootTable()));
 		BLOCK_THAT_DROPS_NOTHING = createBlock(BLOCK_THAT_DROPS_NOTHING_KEY, BlockBehaviour.Properties.of().noLootTable());
 
-		SIMPLE_ENTITY_TYPE = createEntityType(SIMPLE_ENTITY_TYPE_KEY, EntityType.Builder.createNothing(MobCategory.MISC));
+		SIMPLE_ENTITY_TYPE = createEntityType(SIMPLE_ENTITY_TYPE_KEY, EntityType.Builder.createNothing(MobCategory.MONSTER));
 		ENTITY_TYPE_WITHOUT_LOOT_TABLE = createEntityType(ENTITY_TYPE_WITHOUT_LOOT_TABLE_KEY, EntityType.Builder.createNothing(MobCategory.MISC));
 
 		CreativeModeTabEvents.modifyOutputEvent(SIMPLE_ITEM_GROUP).register(entries -> entries.accept(SIMPLE_BLOCK));


### PR DESCRIPTION
Without this fix mods with custom entity types in categories used by vanilla advancement generation and validation (like monster) won't be able to use datagen at all.