### PR TITLE
Improve FabricLanguageProvider

### DIFF
--- a/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
+++ b/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/api/datagen/v1/provider/FabricLanguageProvider.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 
 import com.google.gson.JsonObject;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
@@ -84,18 +85,23 @@ public abstract class FabricLanguageProvider implements DataProvider {
 
 	@Override
 	public CompletableFuture<?> run(CachedOutput output) {
-		TreeMap<String, String> translationEntries = new TreeMap<>();
-
 		return this.registryLookup.thenCompose(lookup -> {
-			generateTranslations(lookup, (String key, String value) -> {
-				Objects.requireNonNull(key);
-				Objects.requireNonNull(value);
+			TreeMap<String, String> translationEntries = new TreeMap<>();
 
-				if (translationEntries.containsKey(key)) {
-					throw new RuntimeException("Existing translation key found - " + key + " - Duplicate will be ignored.");
+			generateTranslations(lookup, new TranslationBuilder() {
+				@Override
+				public boolean has(String translationKey) {
+					Objects.requireNonNull(translationKey, "translationKey");
+					return translationEntries.containsKey(translationKey);
 				}
 
-				translationEntries.put(key, value);
+				@Override
+				@Nullable
+				public String overwrite(String translationKey, String value) {
+					Objects.requireNonNull(translationKey, "translationKey");
+					Objects.requireNonNull(value, "value");
+					return translationEntries.put(translationKey, value);
+				}
 			});
 
 			JsonObject langEntryJson = new JsonObject();
@@ -128,15 +134,41 @@ public abstract class FabricLanguageProvider implements DataProvider {
 	 * A consumer used by {@link FabricLanguageProvider#generateTranslations}.
 	 */
 	@ApiStatus.NonExtendable
-	@FunctionalInterface
 	public interface TranslationBuilder {
+		/**
+		 * Returns whether this data generator has already added the given translation key.
+		 *
+		 * @param translationKey The key of the translation.
+		 * @return Whether this data generator has already added the key.
+		 */
+		boolean has(String translationKey);
+
+		/**
+		 * Adds a translation, overwriting a translation if it exists.
+		 *
+		 * @param translationKey The key of the translation.
+		 * @param value The value of the entry.
+		 * @return The overwritten value, or {@code null} if no value was overwritten.
+		 */
+		@Nullable
+		String overwrite(String translationKey, String value);
+
 		/**
 		 * Adds a translation.
 		 *
 		 * @param translationKey The key of the translation.
 		 * @param value          The value of the entry.
+		 * @throws IllegalStateException If the translation key already exists.
 		 */
-		void add(String translationKey, String value);
+		default void add(String translationKey, String value) {
+			String overwrittenValue = overwrite(translationKey, value);
+
+			if (overwrittenValue != null) {
+				// we overwrote something, restore back to that value and then throw
+				overwrite(translationKey, overwrittenValue);
+				throw new IllegalStateException("Existing translation key found - " + translationKey + " - Duplicate will be ignored.");
+			}
+		}
 
 		/**
 		 * Adds a translation for an {@link Item}.
@@ -163,8 +195,20 @@ public abstract class FabricLanguageProvider implements DataProvider {
 		 *
 		 * @param resourceKey The {@link ResourceKey} to get the translation key from.
 		 * @param value The value of the entry.
+		 * @deprecated Use {@link #addCreativeModeTab} instead.
 		 */
+		@Deprecated
 		default void add(ResourceKey<CreativeModeTab> resourceKey, String value) {
+			addCreativeModeTab(resourceKey, value);
+		}
+
+		/**
+		 * Adds a translation for an {@link CreativeModeTab}.
+		 *
+		 * @param resourceKey The {@link ResourceKey} to get the translation key from.
+		 * @param value The value of the entry.
+		 */
+		default void addCreativeModeTab(ResourceKey<CreativeModeTab> resourceKey, String value) {
 			final CreativeModeTab group = BuiltInRegistries.CREATIVE_MODE_TAB.getValueOrThrow(resourceKey);
 			final ComponentContents content = group.getDisplayName().getContents();
 
@@ -201,8 +245,20 @@ public abstract class FabricLanguageProvider implements DataProvider {
 		 *
 		 * @param attribute The {@link Attribute} to get the translation key from.
 		 * @param value     The value of the entry.
+		 * @deprecated Use {@link #addAttribute} instead.
 		 */
+		@Deprecated
 		default void add(Holder<Attribute> attribute, String value) {
+			addAttribute(attribute, value);
+		}
+
+		/**
+		 * Adds a translation for an {@link Attribute}.
+		 *
+		 * @param attribute The {@link Attribute} to get the translation key from.
+		 * @param value     The value of the entry.
+		 */
+		default void addAttribute(Holder<Attribute> attribute, String value) {
 			add(attribute.value().getDescriptionId(), value);
 		}
 
@@ -263,6 +319,7 @@ public abstract class FabricLanguageProvider implements DataProvider {
 		 *
 		 * @param existingLanguageFile The path to the existing language file.
 		 * @throws IOException If loading the language file failed.
+		 * @throws IllegalStateException If the translation file contains any translation key that already exists.
 		 */
 		default void add(Path existingLanguageFile) throws IOException {
 			try (Reader reader = Files.newBufferedReader(existingLanguageFile)) {
@@ -270,6 +327,22 @@ public abstract class FabricLanguageProvider implements DataProvider {
 
 				for (String key : translations.keySet()) {
 					add(key, translations.get(key).getAsString());
+				}
+			}
+		}
+
+		/**
+		 * Merges an existing language file into the generated language file, overwriting existing translations.
+		 *
+		 * @param existingLanguageFile The path to the existing language file.
+		 * @throws IOException If loading the language file failed.
+		 */
+		default void overwriteWith(Path existingLanguageFile) throws IOException {
+			try (Reader reader = Files.newBufferedReader(existingLanguageFile)) {
+				JsonObject translations = StrictJsonParser.parse(reader).getAsJsonObject();
+
+				for (String key : translations.keySet()) {
+					overwrite(key, translations.get(key).getAsString());
 				}
 			}
 		}


### PR DESCRIPTION
When using `FabricLanguageProvider`, there are a few issues I have found that this PR attempts to resolve:

- The `add` method throws a `RuntimeException` if a translation already exists, meaning there is no supported way to overwrite a translation that already exists, or check if a translation exists.
- The `add(Path)` method (which merges an existing language file) would IMO be most useful if it has the ability to overwrite existing translations.
- Some `add` overloads take generic types like `ResourceKey` and `Holder`, while being specific to the parameter of those generic types, which due to type erasure prevents further overloads with those types with different generic parameters. This has already caused a problem with both `add(ResourceKey<CreativeModeTab>)` and `add(ResourceKey<Enchantment>)` being needed. This has meant that `add(ResourceKey<Enchantment>)` had to be named `addEnchantment`, causing inconsistency and potential confusion in future when more of these are needed.

The solutions I came up with
- Added a `has` method to check for existing translations.
- Added an `overwrite` method to overwrite existing translations if they exist.
- Added an `overwriteWith(Path)` method, which is equivalent to `add(Path)` but overwrites existing entries.
- Changed the type of exception thrown when a translation key exists to the more appropriate `IllegalStateException`, and documented the type of exception thrown. This is a subclass of `RuntimeException` meaning backwards compatibility is maintained in case someone is using this method and catching `RuntimeException`. In the extremely unlikely case that someone has a catch block for `IllegalStateException` as well for something else, backwards compatibility is not preserved and their code will need to be updated.
- Deprecated `add(ResourceKey<CreativeModeTab>)` and `add(Holder<Attribute>)` in favour of new `addCreativeModeTab` and `addAttribute` methods.