### PR TITLE
Fix loot providers lacking reloadable registry context

### DIFF
--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableHolderProvider.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableHolderProvider.java
@@ -46,6 +46,7 @@ public class LootTableHolderProvider implements HolderLookup.Provider {
 		if (registryInfoLookup.lookup(key).isEmpty()) {
 			return Optional.empty();
 		}
+
 		return Optional.of(new LootTableLookup<>(key, registryInfoLookup.lookup(key).orElseThrow(), holderLookup.lookup(key).orElseThrow()));
 	}
 

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableHolderProvider.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableHolderProvider.java
@@ -28,27 +28,30 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 
 public class LootTableHolderProvider implements HolderLookup.Provider {
-	private final HolderLookup.Provider provider;
 	private final RegistryOps.RegistryInfoLookup registryInfoLookup;
+	private final HolderLookup.Provider holderLookup;
 
-	public LootTableHolderProvider(HolderLookup.Provider provider, RegistryOps.RegistryInfoLookup registryInfoLookup) {
-		this.provider = provider;
+	public LootTableHolderProvider(RegistryOps.RegistryInfoLookup registryInfoLookup, HolderLookup.Provider holderLookup) {
 		this.registryInfoLookup = registryInfoLookup;
+		this.holderLookup = holderLookup;
 	}
 
 	@Override
 	public Stream<ResourceKey<? extends Registry<?>>> listRegistryKeys() {
-		return provider.listRegistryKeys();
+		return holderLookup.listRegistryKeys();
 	}
 
 	@Override
 	public <A> Optional<? extends HolderLookup.RegistryLookup<A>> lookup(ResourceKey<? extends Registry<? extends A>> key) {
-		return Optional.of(new LootTableLookup<>(registryInfoLookup.lookup(key).orElseThrow(), provider.lookup(key).orElseThrow()));
+		if (registryInfoLookup.lookup(key).isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(new LootTableLookup<>(key, registryInfoLookup.lookup(key).orElseThrow(), holderLookup.lookup(key).orElseThrow()));
 	}
 
 	@Override
 	public <A> Optional<Holder.Reference<A>> get(ResourceKey<A> id) {
-		return registryInfoLookup.lookup(id.registryKey()).orElseThrow().get(id);
+		return registryInfoLookup.lookup(id.registryKey()).flatMap(getter -> getter.get(id));
 	}
 
 	@Override
@@ -63,6 +66,6 @@ public class LootTableHolderProvider implements HolderLookup.Provider {
 
 	@Override
 	public <T> Optional<HolderSet.Named<T>> get(TagKey<T> id) {
-		return registryInfoLookup.lookup(id.registry()).orElseThrow().get(id);
+		return registryInfoLookup.lookup(id.registry()).flatMap(getter -> getter.get(id));
 	}
 }

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableHolderProvider.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableHolderProvider.java
@@ -27,8 +27,10 @@ import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 
-public class LootTableHolderProvider implements HolderLookup.Provider {
+public final class LootTableHolderProvider implements HolderLookup.Provider {
+	// RegistryInfoLookup can access reloadable registries like loot tables, but cannot list elements or tags.
 	private final RegistryOps.RegistryInfoLookup registryInfoLookup;
+	// HolderLookup.Provider can list elements and tags, but does not have access to reloadable registries like loot tables.
 	private final HolderLookup.Provider holderLookup;
 
 	public LootTableHolderProvider(RegistryOps.RegistryInfoLookup registryInfoLookup, HolderLookup.Provider holderLookup) {
@@ -43,11 +45,13 @@ public class LootTableHolderProvider implements HolderLookup.Provider {
 
 	@Override
 	public <A> Optional<? extends HolderLookup.RegistryLookup<A>> lookup(ResourceKey<? extends Registry<? extends A>> key) {
+		// If the registry info lookup doesn't have access to the registry, it really doesn't exist.
+		// This isn't checked for the holder lookup, as it is not used for actual registry querying.
 		if (registryInfoLookup.lookup(key).isEmpty()) {
 			return Optional.empty();
 		}
 
-		return Optional.of(new LootTableLookup<>(key, registryInfoLookup.lookup(key).orElseThrow(), holderLookup.lookup(key).orElseThrow()));
+		return Optional.of(new LootTableLookup<>(key, registryInfoLookup.lookup(key).orElseThrow(), holderLookup.lookup(key).orElse(null)));
 	}
 
 	@Override

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableHolderProvider.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableHolderProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.loot;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.TagKey;
+
+public class LootTableHolderProvider implements HolderLookup.Provider {
+	private final HolderLookup.Provider provider;
+	private final RegistryOps.RegistryInfoLookup registryInfoLookup;
+
+	public LootTableHolderProvider(HolderLookup.Provider provider, RegistryOps.RegistryInfoLookup registryInfoLookup) {
+		this.provider = provider;
+		this.registryInfoLookup = registryInfoLookup;
+	}
+
+	@Override
+	public Stream<ResourceKey<? extends Registry<?>>> listRegistryKeys() {
+		return provider.listRegistryKeys();
+	}
+
+	@Override
+	public <A> Optional<? extends HolderLookup.RegistryLookup<A>> lookup(ResourceKey<? extends Registry<? extends A>> key) {
+		return Optional.of(new LootTableLookup<>(registryInfoLookup.lookup(key).orElseThrow(), provider.lookup(key).orElseThrow()));
+	}
+
+	@Override
+	public <A> Optional<Holder.Reference<A>> get(ResourceKey<A> id) {
+		return registryInfoLookup.lookup(id.registryKey()).orElseThrow().get(id);
+	}
+
+	@Override
+	public <T> Holder.Reference<T> getOrThrow(ResourceKey<T> id) {
+		return registryInfoLookup.lookup(id.registryKey()).orElseThrow().getOrThrow(id);
+	}
+
+	@Override
+	public <T> HolderSet.Named<T> getOrThrow(TagKey<T> id) {
+		return registryInfoLookup.lookup(id.registry()).orElseThrow().getOrThrow(id);
+	}
+
+	@Override
+	public <T> Optional<HolderSet.Named<T>> get(TagKey<T> id) {
+		return registryInfoLookup.lookup(id.registry()).orElseThrow().get(id);
+	}
+}

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
@@ -30,10 +30,12 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 
 public class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> {
+	private final ResourceKey<? extends Registry<? extends T>> key;
 	private final HolderGetter<T> lookup;
 	private final RegistryLookup<T> holderLookup;
 
-	public LootTableLookup(HolderGetter<T> registryLookup, RegistryLookup<T> holderLookup) {
+	public LootTableLookup(ResourceKey<? extends Registry<? extends T>> key, HolderGetter<T> registryLookup, RegistryLookup<T> holderLookup) {
+		this.key = key;
 		this.lookup = registryLookup;
 		this.holderLookup = holderLookup;
 	}
@@ -50,7 +52,7 @@ public class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> {
 
 	@Override
 	public ResourceKey<? extends Registry<? extends T>> key() {
-		return holderLookup.key();
+		return key;
 	}
 
 	@Override

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
@@ -31,41 +31,41 @@ import net.minecraft.tags.TagKey;
 
 public class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> {
 
-	private final Optional<HolderGetter<T>> lookup;
-	private final Optional<? extends RegistryLookup<T>> holderLookup;
+	private final HolderGetter<T> lookup;
+	private final RegistryLookup<T> holderLookup;
 
-	public LootTableLookup(Optional<HolderGetter<T>> registryLookup, Optional<? extends RegistryLookup<T>> holderLookup) {
+	public LootTableLookup(HolderGetter<T> registryLookup, RegistryLookup<T> holderLookup) {
 		this.lookup = registryLookup;
 		this.holderLookup = holderLookup;
 	}
 
 	@Override
 	public Stream<Holder.Reference<T>> listElements() {
-		return holderLookup.orElseThrow().listElements();
+		return holderLookup.listElements();
 	}
 
 	@Override
 	public Stream<HolderSet.Named<T>> listTags() {
-		return holderLookup.orElseThrow().listTags();
+		return holderLookup.listTags();
 	}
 
 	@Override
 	public ResourceKey<? extends Registry<? extends T>> key() {
-		return holderLookup.orElseThrow().key();
+		return holderLookup.key();
 	}
 
 	@Override
 	public Lifecycle registryLifecycle() {
-		return holderLookup.orElseThrow().registryLifecycle();
+		return holderLookup.registryLifecycle();
 	}
 
 	@Override
 	public Optional<Holder.Reference<T>> get(ResourceKey<T> id) {
-		return lookup.orElseThrow().get(id);
+		return lookup.get(id);
 	}
 
 	@Override
 	public Optional<HolderSet.Named<T>> get(TagKey<T> id) {
-		return lookup.orElseThrow().get(id);
+		return lookup.get(id);
 	}
 }

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import com.mojang.serialization.Lifecycle;
+import org.jspecify.annotations.Nullable;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderGetter;
@@ -29,12 +30,14 @@ import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 
-public class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> {
+public final class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> {
 	private final ResourceKey<? extends Registry<? extends T>> key;
+	// Obtained from RegistryInfoLookup, can access reloadable registries like loot tables, but cannot list elements or tags.
 	private final HolderGetter<T> lookup;
+	// Obtained from HolderLookup.Provider, can list elements and tags, but does not have access to reloadable registries like loot tables.
 	private final RegistryLookup<T> holderLookup;
 
-	public LootTableLookup(ResourceKey<? extends Registry<? extends T>> key, HolderGetter<T> registryLookup, RegistryLookup<T> holderLookup) {
+	public LootTableLookup(ResourceKey<? extends Registry<? extends T>> key, HolderGetter<T> registryLookup, @Nullable RegistryLookup<T> holderLookup) {
 		this.key = key;
 		this.lookup = registryLookup;
 		this.holderLookup = holderLookup;
@@ -42,12 +45,16 @@ public class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> {
 
 	@Override
 	public Stream<Holder.Reference<T>> listElements() {
-		return holderLookup.listElements();
+		if (holderLookup != null)
+			return holderLookup.listElements();
+		return Stream.empty();
 	}
 
 	@Override
 	public Stream<HolderSet.Named<T>> listTags() {
-		return holderLookup.listTags();
+		if (holderLookup != null)
+			return holderLookup.listTags();
+		return Stream.empty();
 	}
 
 	@Override
@@ -57,7 +64,9 @@ public class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> {
 
 	@Override
 	public Lifecycle registryLifecycle() {
-		return holderLookup.registryLifecycle();
+		if (holderLookup != null)
+			return holderLookup.registryLifecycle();
+		return Lifecycle.stable();
 	}
 
 	@Override

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
@@ -45,15 +45,19 @@ public final class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> 
 
 	@Override
 	public Stream<Holder.Reference<T>> listElements() {
-		if (holderLookup != null)
+		if (holderLookup != null) {
 			return holderLookup.listElements();
+		}
+
 		return Stream.empty();
 	}
 
 	@Override
 	public Stream<HolderSet.Named<T>> listTags() {
-		if (holderLookup != null)
+		if (holderLookup != null) {
 			return holderLookup.listTags();
+		}
+
 		return Stream.empty();
 	}
 
@@ -64,8 +68,10 @@ public final class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> 
 
 	@Override
 	public Lifecycle registryLifecycle() {
-		if (holderLookup != null)
+		if (holderLookup != null) {
 			return holderLookup.registryLifecycle();
+		}
+
 		return Lifecycle.stable();
 	}
 

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
@@ -35,7 +35,7 @@ public final class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> 
 	// Obtained from RegistryInfoLookup, can access reloadable registries like loot tables, but cannot list elements or tags.
 	private final HolderGetter<T> lookup;
 	// Obtained from HolderLookup.Provider, can list elements and tags, but does not have access to reloadable registries like loot tables.
-	private final RegistryLookup<T> holderLookup;
+	private final @Nullable RegistryLookup<T> holderLookup;
 
 	public LootTableLookup(ResourceKey<? extends Registry<? extends T>> key, HolderGetter<T> registryLookup, @Nullable RegistryLookup<T> holderLookup) {
 		this.key = key;

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.impl.loot;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.mojang.serialization.Lifecycle;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.TagKey;
+
+public class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> {
+
+	private final Optional<HolderGetter<T>> lookup;
+	private final Optional<? extends RegistryLookup<T>> holderLookup;
+
+	public LootTableLookup(Optional<HolderGetter<T>> registryLookup, Optional<? extends RegistryLookup<T>> holderLookup) {
+		this.lookup = registryLookup;
+		this.holderLookup = holderLookup;
+	}
+
+	@Override
+	public Stream<Holder.Reference<T>> listElements() {
+		return holderLookup.orElseThrow().listElements();
+	}
+
+	@Override
+	public Stream<HolderSet.Named<T>> listTags() {
+		return holderLookup.orElseThrow().listTags();
+	}
+
+	@Override
+	public ResourceKey<? extends Registry<? extends T>> key() {
+		return holderLookup.orElseThrow().key();
+	}
+
+	@Override
+	public Lifecycle registryLifecycle() {
+		return holderLookup.orElseThrow().registryLifecycle();
+	}
+
+	@Override
+	public Optional<Holder.Reference<T>> get(ResourceKey<T> id) {
+		return lookup.orElseThrow().get(id);
+	}
+
+	@Override
+	public Optional<HolderSet.Named<T>> get(TagKey<T> id) {
+		return lookup.orElseThrow().get(id);
+	}
+}

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/impl/loot/LootTableLookup.java
@@ -30,7 +30,6 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 
 public class LootTableLookup<T> implements HolderLookup.RegistryLookup<T> {
-
 	private final HolderGetter<T> lookup;
 	private final RegistryLookup<T> holderLookup;
 

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
@@ -16,9 +16,6 @@
 
 package net.fabricmc.fabric.mixin.loot;
 
-import java.util.Optional;
-import java.util.stream.Stream;
-
 import com.google.gson.JsonElement;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -29,9 +26,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
-import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
@@ -40,7 +35,7 @@ import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.level.storage.loot.LootTable;
 
-import net.fabricmc.fabric.impl.loot.LootTableLookup;
+import net.fabricmc.fabric.impl.loot.LootTableHolderProvider;
 import net.fabricmc.fabric.impl.loot.LootUtil;
 
 @Mixin(ResourceManagerRegistryLoadTask.class)
@@ -66,22 +61,7 @@ abstract class ResourceManagerRegistryLoadTaskMixin {
 			return result;
 		}
 
-		var fullProvider = new HolderLookup.Provider() {
-			@Override
-			public Stream<ResourceKey<? extends Registry<?>>> listRegistryKeys() {
-				return provider.listRegistryKeys();
-			}
-
-			@Override
-			public <A> Optional<? extends HolderLookup.RegistryLookup<A>> lookup(ResourceKey<? extends Registry<? extends A>> key) {
-				return Optional.of(new LootTableLookup<>(registryInfoLookup.lookup(key).orElseThrow(), provider.lookup(key).orElseThrow()));
-			}
-
-			@Override
-			public <A> Optional<Holder.Reference<A>> get(ResourceKey<A> id) {
-				return registryInfoLookup.lookup(id.registryKey()).orElseThrow().get(id);
-			}
-		};
+		var fullProvider = new LootTableHolderProvider(provider, registryInfoLookup);
 
 		return result.mapLeft(value -> (T) LootUtil.modifyLootTable(
 				(ResourceKey<LootTable>) key,

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
@@ -61,7 +61,7 @@ abstract class ResourceManagerRegistryLoadTaskMixin {
 			return result;
 		}
 
-		var fullProvider = new LootTableHolderProvider(provider, registryInfoLookup);
+		var fullProvider = new LootTableHolderProvider(registryInfoLookup, provider);
 
 		return result.mapLeft(value -> (T) LootUtil.modifyLootTable(
 				(ResourceKey<LootTable>) key,

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
@@ -61,6 +61,7 @@ abstract class ResourceManagerRegistryLoadTaskMixin {
 			return result;
 		}
 
+		// Merge the HolderLookup.Provider and RegistryOps.RegistryInfoLookup into a HolderLookup.Provider with access to reloadable registries.
 		var fullProvider = new LootTableHolderProvider(registryInfoLookup, provider);
 
 		return result.mapLeft(value -> (T) LootUtil.modifyLootTable(

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.fabric.mixin.loot;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import com.google.gson.JsonElement;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -26,7 +29,9 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
@@ -35,6 +40,7 @@ import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.level.storage.loot.LootTable;
 
+import net.fabricmc.fabric.impl.loot.LootTableLookup;
 import net.fabricmc.fabric.impl.loot.LootUtil;
 
 @Mixin(ResourceManagerRegistryLoadTask.class)
@@ -52,7 +58,27 @@ abstract class ResourceManagerRegistryLoadTaskMixin {
 			return result;
 		}
 
+
 		HolderLookup.Provider provider = LootUtil.getActiveReloadProvider(this.resourceManager);
+
+		RegistryOps.RegistryInfoLookup registryInfoLookup = ops::getter;
+
+		var fullProvider = new HolderLookup.Provider() {
+			@Override
+			public Stream<ResourceKey<? extends Registry<?>>> listRegistryKeys() {
+				return provider.listRegistryKeys();
+			}
+
+			@Override
+			public <T> Optional<? extends HolderLookup.RegistryLookup<T>> lookup(ResourceKey<? extends Registry<? extends T>> key) {
+				return Optional.of(new LootTableLookup<>(registryInfoLookup.lookup(key), provider.lookup(key)));
+			}
+
+			@Override
+			public <T> Optional<Holder.Reference<T>> get(ResourceKey<T> id) {
+				return registryInfoLookup.lookup(id.registryKey()).orElseThrow().get(id);
+			}
+		};
 
 		if (provider == null) {
 			return result;
@@ -62,7 +88,7 @@ abstract class ResourceManagerRegistryLoadTaskMixin {
 				(ResourceKey<LootTable>) key,
 				(LootTable) value,
 				LootUtil.determineSource(resource),
-				provider
+				fullProvider
 		));
 	}
 }

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
@@ -74,7 +74,7 @@ abstract class ResourceManagerRegistryLoadTaskMixin {
 
 			@Override
 			public <A> Optional<? extends HolderLookup.RegistryLookup<A>> lookup(ResourceKey<? extends Registry<? extends A>> key) {
-				return Optional.of(new LootTableLookup<>(registryInfoLookup.lookup(key).orElse(null), provider.lookup(key).orElse(null)));
+				return Optional.of(new LootTableLookup<>(registryInfoLookup.lookup(key).orElseThrow(), provider.lookup(key).orElseThrow()));
 			}
 
 			@Override

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
@@ -63,6 +63,10 @@ abstract class ResourceManagerRegistryLoadTaskMixin {
 
 		RegistryOps.RegistryInfoLookup registryInfoLookup = ops::getter;
 
+		if (provider == null) {
+			return result;
+		}
+
 		var fullProvider = new HolderLookup.Provider() {
 			@Override
 			public Stream<ResourceKey<? extends Registry<?>>> listRegistryKeys() {
@@ -70,19 +74,15 @@ abstract class ResourceManagerRegistryLoadTaskMixin {
 			}
 
 			@Override
-			public <T> Optional<? extends HolderLookup.RegistryLookup<T>> lookup(ResourceKey<? extends Registry<? extends T>> key) {
-				return Optional.of(new LootTableLookup<>(registryInfoLookup.lookup(key), provider.lookup(key)));
+			public <A> Optional<? extends HolderLookup.RegistryLookup<A>> lookup(ResourceKey<? extends Registry<? extends A>> key) {
+				return Optional.of(new LootTableLookup<>(registryInfoLookup.lookup(key).orElse(null), provider.lookup(key).orElse(null)));
 			}
 
 			@Override
-			public <T> Optional<Holder.Reference<T>> get(ResourceKey<T> id) {
+			public <A> Optional<Holder.Reference<A>> get(ResourceKey<A> id) {
 				return registryInfoLookup.lookup(id.registryKey()).orElseThrow().get(id);
 			}
 		};
-
-		if (provider == null) {
-			return result;
-		}
 
 		return result.mapLeft(value -> (T) LootUtil.modifyLootTable(
 				(ResourceKey<LootTable>) key,

--- a/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
+++ b/fabric-loot-api-v3/src/main/java/net/fabricmc/fabric/mixin/loot/ResourceManagerRegistryLoadTaskMixin.java
@@ -58,7 +58,6 @@ abstract class ResourceManagerRegistryLoadTaskMixin {
 			return result;
 		}
 
-
 		HolderLookup.Provider provider = LootUtil.getActiveReloadProvider(this.resourceManager);
 
 		RegistryOps.RegistryInfoLookup registryInfoLookup = ops::getter;

--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootGameTest.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootGameTest.java
@@ -62,6 +62,12 @@ public final class LootGameTest {
 		emeraldDrops.assertEquals(new ItemStack(Items.EMERALD));
 		LootTableDrops woolDrops = LootTableDrops.block(helper, Blocks.WOOL.yellow()).seed(490234).drop();
 		woolDrops.assertEquals(new ItemStack(Blocks.WOOL.yellow()));
+		// Pink wool should drop either pink wool or armadillo scutes.
+		// Let's generate the drops with specific seeds to check.
+		LootTableDrops pinkDrops = LootTableDrops.block(helper, Blocks.WOOL.pink()).seed(490234).drop();
+		pinkDrops.assertEquals(new ItemStack(Blocks.WOOL.pink()));
+		LootTableDrops scuteDrops = LootTableDrops.block(helper, Blocks.WOOL.pink()).seed(1).drop();
+		scuteDrops.assertEquals(new ItemStack(Items.ARMADILLO_SCUTE));
 		helper.succeed();
 	}
 

--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -36,10 +36,12 @@ import net.minecraft.world.item.crafting.SingleRecipeInput;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.storage.loot.BuiltInLootTables;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.entries.NestedLootTable;
 import net.minecraft.world.level.storage.loot.functions.SetEnchantmentsFunction;
 import net.minecraft.world.level.storage.loot.functions.SetNameFunction;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
@@ -111,6 +113,12 @@ public class LootTest implements ModInitializer {
 			// emeralds to the same loot pool.
 			if (Blocks.WOOL.yellow().getLootTable().orElse(null) == key) {
 				tableBuilder.modifyPools(poolBuilder -> poolBuilder.add(LootItem.lootTableItem(Items.EMERALD)));
+			}
+
+			// Modify pink wool to drop *either* pink wool or end city loot chests by adding
+			// end city loot chests to the same loot pool.
+			if (Blocks.WOOL.pink().getLootTable().orElse(null) == key) {
+				tableBuilder.modifyPools(poolBuilder -> poolBuilder.add(NestedLootTable.lootTableReference(provider.getOrThrow(BuiltInLootTables.END_CITY_TREASURE))));
 			}
 		});
 

--- a/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
+++ b/fabric-loot-api-v3/src/testmod/java/net/fabricmc/fabric/test/loot/LootTest.java
@@ -115,10 +115,10 @@ public class LootTest implements ModInitializer {
 				tableBuilder.modifyPools(poolBuilder -> poolBuilder.add(LootItem.lootTableItem(Items.EMERALD)));
 			}
 
-			// Modify pink wool to drop *either* pink wool or end city loot chests by adding
-			// end city loot chests to the same loot pool.
+			// Modify pink wool to drop *either* pink wool or armadillo scutes by adding
+			// armadillo shedding to the same loot pool.
 			if (Blocks.WOOL.pink().getLootTable().orElse(null) == key) {
-				tableBuilder.modifyPools(poolBuilder -> poolBuilder.add(NestedLootTable.lootTableReference(provider.getOrThrow(BuiltInLootTables.END_CITY_TREASURE))));
+				tableBuilder.modifyPools(poolBuilder -> poolBuilder.add(NestedLootTable.lootTableReference(provider.getOrThrow(BuiltInLootTables.ARMADILLO_SHED))));
 			}
 		});
 


### PR DESCRIPTION
In 26.3, the `HolderLookup.Provider` used in loot table modification events does not have access to reloadable registries, however the `RegistryOps` also provided by the mixin does. This PR combines the two to create a `HolderLookup` with access to all registries. Tested with Farmer's Delight Refabricated and confirmed this allows the mod's loot table events to function without the workarounds previously used.

Implementation inspired by #5581, but does not introduce a new event.