### PR TITLE
Remove `BlockTransformer` codec size limit

### DIFF
--- a/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/BlockTransformerMixin.java
+++ b/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/BlockTransformerMixin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.mixin.item;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.core.component.BlockTransformer;
+
+@Mixin(BlockTransformer.class)
+public class BlockTransformerMixin {
+	@ModifyArg(method = "<clinit>", at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/Codec;listOf(II)Lcom/mojang/serialization/Codec;"), index = 1)
+	private static int removeBlockTransformerSizeLimit(int maxSize) {
+		return Integer.MAX_VALUE;
+	}
+}

--- a/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
+++ b/fabric-item-api-v1/src/main/resources/fabric-item-api-v1.mixins.json
@@ -6,6 +6,7 @@
     "AbstractContainerMenuMixin",
     "AbstractFurnaceBlockEntityMixin",
     "AnvilMenuMixin",
+    "BlockTransformerMixin",
     "BrewingStandBlockEntityMixin",
     "BuiltInRegistriesMixin",
     "CraftingRecipeMixin",


### PR DESCRIPTION
Vanilla arbitrarily limits the size of `BlockTransformer`s to 200 entries in the `BlockTransformer` codec.
https://mcsrc.dev/2/26.3-pre-3/net/minecraft/core/component/BlockTransformer#L52

This PR changes the max size of the codec from 200 to `Integer#MAX_VALUE`.

My personal use case is adding waxing and scraping for copper blocks in Additional Lanterns through `OxidizableBlocksRegistry#registerWaxable` and `OxidizableBlocksRegistry#registerNextStage`. The mod on its own adds more than 200 entries to the `minecraft:axe` block transformer and thus fails to load data registries when trying to join a world.